### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Expected Behavior
+
+# Actual Behavior
+
+# Steps to Reproduce the Problem
+
+1.
+2.
+3.
+
+# Additional Info
+
+- Kubernetes version:
+
+  **Output of `kubectl version`:**
+
+```
+(paste your output here)
+```
+
+- Tekton Pipeline version:
+
+  **Output of `tkn version` or `kubectl get pods -n tekton-pipelines -l app=tekton-pipelines-controller -o=jsonpath='{.items[0].metadata.labels.version}'`**
+
+```
+(paste your output here)
+```
+
+
+<!-- Any other additional information -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Feature request
+
+<!-- Please describe the feature request and why you would like to have it -->
+
+### Use case
+
+<!-- Please add a concrete use case to demonstrate how such a feature would add value for the user. If you don't have a use case for your feature, please remove this section (however providing a good use case increases the likelihood to be picked up) -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
+
+# Changes
+
+<!-- Describe your changes here- ideally you can get that description straight from
+your descriptive commit message(s)! -->
+
+# Submitter Checklist
+
+These are the criteria that every PR should meet, please check them off as you
+review them:
+
+TODO: add submitter checklist details


### PR DESCRIPTION
This commit adds the GitHub issue templates (`Bug report` & `Feature request`) and PR template as required in: https://github.com/tektoncd/community/blob/main/process.md#project-requirements

The issue templates are copied from: https://github.com/tektoncd/pipeline
The PR template is copied from: https://github.com/tektoncd/catalog