### PR TITLE
Migrate golang-build and golang-test resources

### DIFF
--- a/task/golang-build/OWNERS
+++ b/task/golang-build/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- bobcatfish
+- vdemeester
+- vinamra28
+

--- a/task/golang-build/README.md
+++ b/task/golang-build/README.md
@@ -1,0 +1,54 @@
+# Golang Build
+
+This Task is Golang task to build Go projects.
+
+## Install the task
+
+TODO
+
+
+### Parameters
+
+* **package**: base package under test
+* **packages**: packages to test (_default:_ ./...)
+* **version**: golang version to use for tests (_default:_ latest)
+* **flags**: flags to use for `go build` command (_default:_ -v)
+* **GOOS**: operating system target (_default:_ linux)
+* **GOARCH**: architecture target (_default:_ amd64)
+* **GO111MODULE**: value of module support (_default:_ auto)
+* **GOCACHE**: value for go caching path (_default:_ "")
+* **GOMODCACHE**: value for go module caching path (_default:_ "")
+* **CGO_ENABLED**: value for go cgo tool toggle (_default:_ "")
+* **GOSUMDB**: value for go checksum database url (_default:_ "")
+
+### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`,  and `linux/ppc64le` platforms.
+
+Specify value for `GOARCH` parameter according to the desired target architecture.
+
+## Usage
+
+This TaskRun runs the Task to compile commands from
+[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline).
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: build-my-code
+spec:
+  taskRef:
+    name: golang-build
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+  params:
+  - name: package
+    value: github.com/tektoncd/pipeline
+```

--- a/task/golang-build/golang-build.yaml
+++ b/task/golang-build/golang-build.yaml
@@ -1,0 +1,81 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: golang-build
+  labels:
+    app.kubernetes.io/version: "1.0.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Build Tools
+    tekton.dev/tags: build-tool
+    tekton.dev/displayName: "golang build"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+spec:
+  description: >-
+    This Task is Golang task to build Go projects.
+
+  params:
+  - name: package
+    description: base package to build in
+  - name: packages
+    description: "packages to build (default: ./cmd/...)"
+    default: "./cmd/..."
+  - name: version
+    description: golang version to use for builds
+    default: "latest"
+  - name: flags
+    description: flags to use for the test command
+    default: -v
+  - name: GOOS
+    description: "running program's operating system target"
+    default: linux
+  - name: GOARCH
+    description: "running program's architecture target"
+    default: amd64
+  - name: GO111MODULE
+    description: "value of module support"
+    default: auto
+  - name: GOCACHE
+    description: "Go caching directory path"
+    default: ""
+  - name: GOMODCACHE
+    description: "Go mod caching directory path"
+    default: ""
+  - name: CGO_ENABLED
+    description: "Toggle cgo tool during Go build. Use value '0' to disable cgo (for static builds)."
+    default: ""
+  - name: GOSUMDB
+    description: "Go checksum database url. Use value 'off' to disable checksum validation."
+    default: ""
+  workspaces:
+  - name: source
+  steps:
+  - name: build
+    image: docker.io/library/golang:$(params.version)
+    workingDir: $(workspaces.source.path)
+    script: |
+      if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+        SRC_PATH="$GOPATH/src/$(params.package)"
+        mkdir -p $SRC_PATH
+        cp -R "$(workspaces.source.path)"/* $SRC_PATH
+        cd $SRC_PATH
+      fi
+      go build $(params.flags) $(params.packages)
+    env:
+    - name: GOOS
+      value: "$(params.GOOS)"
+    - name: GOARCH
+      value: "$(params.GOARCH)"
+    - name: GO111MODULE
+      value: "$(params.GO111MODULE)"
+    - name: GOCACHE
+      value: "$(params.GOCACHE)"
+    - name: GOMODCACHE
+      value: "$(params.GOMODCACHE)"
+    - name: CGO_ENABLED
+      value: "$(params.CGO_ENABLED)"
+    - name: GOSUMDB
+      value: "$(params.GOSUMDB)"

--- a/task/golang-test/OWNERS
+++ b/task/golang-test/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- bobcatfish
+- vdemeester
+- vinamra28

--- a/task/golang-test/README.md
+++ b/task/golang-test/README.md
@@ -1,0 +1,55 @@
+# Golang Test
+
+This task is a Golang task to test Go projects.
+
+## Install the task
+
+TODO
+
+### Parameters
+
+* **package**: base package to build in
+* **packages**: packages to test (_default:_ ./cmd/...)
+* **context**: path to the directory to use as context (default: .)
+* **version**: golang version to use for builds (_default:_ latest)
+* **flags**: flags to use for `go test` command (_default:_ -race -cover -v)
+* **GOOS**: operating system target (_default:_ linux)
+* **GOARCH**: architecture target (_default:_ amd64)
+* **GO111MODULE**: value of module support (_default:_ auto)
+* **GOCACHE**: value for go caching path (_default:_ "")
+* **GOMODCACHE**: value for go module caching path (_default:_ "")
+
+### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
+Specify value for `GOARCH` parameter according to the desired target architecture.
+Do not use `-race` flag in `flags` parameter for `linux/s390x` platform.
+
+## Usage
+
+This TaskRun runs the Task to run unit-tests on
+[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline).
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: test-my-code
+spec:
+  taskRef:
+    name: golang-test
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+  params:
+  - name: package
+    value: github.com/tektoncd/pipeline
+  - name: packages
+    value: ./pkg/...
+```

--- a/task/golang-test/golang-test.yaml
+++ b/task/golang-test/golang-test.yaml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: golang-test
+  labels:
+    app.kubernetes.io/version: "1.0.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Testing
+    tekton.dev/tags: test
+    tekton.dev/displayName: "golang test"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+spec:
+  description: >-
+    This Task is Golang task to test Go projects.
+
+  params:
+  - name: package
+    description: package (and its children) under test
+  - name: packages
+    description: "packages to test (default: ./...)"
+    default: "./..."
+  - name: context
+    description: path to the directory to use as context.
+    default: "."
+  - name: version
+    description: golang version to use for tests
+    default: "latest"
+  - name: flags
+    description: flags to use for the test command
+    default: -race -cover -v
+  - name: GOOS
+    description: "running program's operating system target"
+    default: linux
+  - name: GOARCH
+    description: "running program's architecture target"
+    default: amd64
+  - name: GO111MODULE
+    description: "value of module support"
+    default: auto
+  - name: GOCACHE
+    description: "Go caching directory path"
+    default: ""
+  - name: GOMODCACHE
+    description: "Go mod caching directory path"
+    default: ""
+  workspaces:
+  - name: source
+  steps:
+  - name: unit-test
+    image: docker.io/library/golang:$(params.version)
+    workingDir: $(workspaces.source.path)
+    script: |
+      if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+         SRC_PATH="$GOPATH/src/$(params.package)"
+         mkdir -p $SRC_PATH
+         cp -R "$(workspaces.source.path)/$(params.context)"/* $SRC_PATH
+         cd $SRC_PATH
+      fi
+      go test $(params.flags) $(params.packages)
+    env:
+    - name: GOOS
+      value: "$(params.GOOS)"
+    - name: GOARCH
+      value: "$(params.GOARCH)"
+    - name: GO111MODULE
+      value: "$(params.GO111MODULE)"
+    - name: GOCACHE
+      value: "$(params.GOCACHE)"
+    - name: GOMODCACHE
+      value: "$(params.GOMODCACHE)"


### PR DESCRIPTION
This commit

- Migrated the [golang-build][golang-build] and [golang-test][golang-test] tasks from the central repo
- Changed the `app.kubernetes.io/version` to `1.0.0`
- Added new annotations required in [tep-0079][tep-0079]

The tests will be updated and migrated in later PRs, the installation in the README.md file will be updated in later PRs.

[golang-build]: https://github.com/tektoncd/catalog/tree/main/task/golang-build/0.3
[golang-test]: https://github.com/tektoncd/catalog/tree/main/task/golang-test/0.2
[tep-0079]: https://github.com/tektoncd/community/blob/main/teps/0079-tekton-catalog-support-tiers.md#cluster