### PR TITLE
Add test cases for golang catalog

### DIFF
--- a/task/golang-build/tests/pipeline.yaml
+++ b/task/golang-build/tests/pipeline.yaml
@@ -1,0 +1,75 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: golang-build-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  params:
+    - name: url
+      description: Repository URL to clone from
+    - name: package
+      description: base package to build in
+    - name: packages
+      description: packages to build
+    - name: flags
+      description: flags to use for the build command
+      default: -v
+    - name: artifact-output
+      description: the output of the package to be verified
+  tasks:
+    - name: fetch-repository  # TODO: use git-clone verified catalog once git-clone is migrated
+      taskRef:
+        resolver: hub
+        params:
+        - name: name
+          value: git-clone
+        - name: version 
+          value: 0.7
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.url)
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: run-build
+      taskRef:
+        name: golang-build
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: package
+          value: $(params.package)
+        - name: packages
+          value: $(params.packages)
+        - name: flags
+          value: $(params.flags)
+    - name: verify-artifact
+      runAfter:
+        - run-build
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: artifact-output
+          value: $(params.artifact-output)
+      taskSpec:
+        params:
+          - name: artifact-output
+        workspaces:
+          - name: source
+        steps:
+          - image: bash
+            script: |
+              if [[ -e $(params.artifact-output) ]]; then 
+                exit 0
+              else
+                exit 1
+              fi

--- a/task/golang-build/tests/pipelineruns.yaml
+++ b/task/golang-build/tests/pipelineruns.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: golang-build-pipeline-run-rest-api-test
+spec:
+  pipelineRef:
+    name: golang-build-pipeline
+  params:
+    - name: url
+      value: https://github.com/chmouel/go-rest-api-test
+    - name: package
+      value: github.com/chmouel/go-rest-api-test
+    - name: packages
+      value: "./"
+    - name: artifact-output
+      value: /workspace/source/api_test
+    - name: flags
+      value: -o /workspace/source/api_test
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Mi
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: golang-build-pipeline-run-hello-example
+spec:
+  pipelineRef:
+    name: golang-build-pipeline
+  params:
+    - name: url
+      value: https://github.com/golang/example
+    - name: package
+      value: golang.org/x/example
+    - name: packages
+      value: "./hello/"
+    - name: artifact-output
+      value: /workspace/source/hello_pkg
+    - name: flags
+      value: -o /workspace/source/hello_pkg
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Mi

--- a/task/golang-test/tests/pipeline.yaml
+++ b/task/golang-test/tests/pipeline.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: golang-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  params:
+    - name: url
+      description: Repository URL to clone from
+    - name: package
+      description: base package to build in
+    - name: packages
+      description: packages to build
+    - name: flags
+      description: flags to use for the build command
+      default: -v
+  tasks:
+    - name: fetch-repository  # TODO: use git-clone verified catalog once git-clone is migrated
+      taskRef:
+        resolver: hub
+        params:
+        - name: name
+          value: git-clone
+        - name: version 
+          value: 0.7
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.url)
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: run-test
+      taskRef:
+        name: golang-test
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: package
+          value: $(params.package)
+        - name: packages
+          value: $(params.packages)
+        - name: flags
+          value: $(params.flags)

--- a/task/golang-test/tests/pipelinerun.yaml
+++ b/task/golang-test/tests/pipelinerun.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: golang-test-pipeline-run-basic-stringutil
+spec:
+  pipelineRef:
+    name: golang-test-pipeline
+  params:
+    - name: url
+      value: https://github.com/golang/example
+    - name: package
+      value: golang.org/x/example
+    - name: packages
+      value: "./stringutil/"
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Mi
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: golang-test-pipeline-run-basic-outyet
+spec:
+  pipelineRef:
+    name: golang-test-pipeline
+  params:
+    - name: url
+      value: https://github.com/golang/example
+    - name: package
+      value: golang.org/x/example
+    - name: packages
+      value: "./outyet/"
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Mi


### PR DESCRIPTION
This commit adds test cases for golang catalog. Golang catalog test script will be sent out separately after  https://github.com/tektoncd/plumbing/pull/1323 is merged.

A tested e2e example can be found in: https://github.com/QuanZhang-William/golang/tree/test-pipelines