### PR TITLE
Remove `Install the task` section in readme

### DIFF
--- a/task/golang-build/README.md
+++ b/task/golang-build/README.md
@@ -2,11 +2,6 @@
 
 This Task is Golang task to build Go projects.
 
-## Install the task
-
-TODO
-
-
 ### Parameters
 
 * **package**: base package under test

--- a/task/golang-test/README.md
+++ b/task/golang-test/README.md
@@ -2,10 +2,6 @@
 
 This task is a Golang task to test Go projects.
 
-## Install the task
-
-TODO
-
 ### Parameters
 
 * **package**: base package to build in


### PR DESCRIPTION
This commit removes the `Install the task` section of the golang-build and golang-test resource as the installation guide is automatically handled by the Artifact Hub in" https://artifacthub.io/packages/tekton-task/golang/golang-build?modal=install