### PR TITLE
Bump pipelines.minVersion to 1.0.0

### DIFF
--- a/task/golang-build/golang-build.yaml
+++ b/task/golang-build/golang-build.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/version: "1.0.0"
   annotations:
-    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/categories: Build Tools
     tekton.dev/tags: build-tool
     tekton.dev/displayName: "golang build"

--- a/task/golang-test/golang-test.yaml
+++ b/task/golang-test/golang-test.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/version: "1.0.0"
   annotations:
-    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/categories: Testing
     tekton.dev/tags: test
     tekton.dev/displayName: "golang test"


### PR DESCRIPTION
## Changes

Bump `tekton.dev/pipelines.minVersion` annotation from `0.12.1` to `1.0.0` in both `golang-build` and `golang-test` tasks.

These tasks use `apiVersion: tekton.dev/v1` which requires Tekton Pipelines >= 1.0.0. The previous minVersion of `0.12.1` was carried over from the old catalog and is incorrect for v1 tasks.

This aligns with the same change made in [tektoncd/catalog](https://github.com/tektoncd/catalog/commit/HEAD) (May 2025).

## Release Notes

```release-note
Bump minimum required Tekton Pipelines version to 1.0.0
```