### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
+
+# Changes
+
+<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
+
+# Submitter Checklist
+
+As the author of this PR, please check off the items in this checklist:
+
+- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
+- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
+- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
+- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
+- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
+
+# Release Notes
+
+```release-note
+NONE
+```


### PR DESCRIPTION
## Changes

Add a standard Tekton pull request template with a submitter checklist aligned with [Tekton community standards](https://github.com/tektoncd/community/blob/main/standards.md).

Adapted from the template used in `tektoncd/pipeline`.

## Release Notes

```release-note
NONE
```