### PR TITLE
Update README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,127 @@
-# golang
-This verified catalog repo holds golang related Tekton resources
+# Golang Tasks for Tekton
+
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/golang)](https://artifacthub.io/packages/search?repo=golang)
+
+This repository contains verified Tekton Tasks for building and testing Go projects.
+
+## Tasks
+
+| Task | Description |
+|------|-------------|
+| [`golang-build`](task/golang-build/) | Build Go packages |
+| [`golang-test`](task/golang-test/) | Run Go tests |
+
+## Installation
+
+Install both tasks:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-build/golang-build.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-test/golang-test.yaml
+```
+
+## Quick Start
+
+### Build
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  generateName: golang-build-run-
+spec:
+  taskRef:
+    name: golang-build
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: package
+      value: github.com/tektoncd/pipeline
+```
+
+### Test
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  generateName: golang-test-run-
+spec:
+  taskRef:
+    name: golang-test
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: package
+      value: github.com/tektoncd/pipeline
+```
+
+### Build and Test Pipeline
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: golang-pipeline-run-
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: shared-data
+    params:
+      - name: package
+        type: string
+    tasks:
+      - name: fetch-source
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: shared-data
+        params:
+          - name: url
+            value: https://github.com/tektoncd/pipeline
+      - name: build
+        runAfter: ["fetch-source"]
+        taskRef:
+          name: golang-build
+        workspaces:
+          - name: source
+            workspace: shared-data
+        params:
+          - name: package
+            value: $(params.package)
+      - name: test
+        runAfter: ["fetch-source"]
+        taskRef:
+          name: golang-test
+        workspaces:
+          - name: source
+            workspace: shared-data
+        params:
+          - name: package
+            value: $(params.package)
+  params:
+    - name: package
+      value: github.com/tektoncd/pipeline
+  workspaces:
+    - name: shared-data
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+```
+
+## Requirements
+
+- Tekton Pipelines **v1.0.0** or later
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

--- a/task/golang-build/README.md
+++ b/task/golang-build/README.md
@@ -1,38 +1,45 @@
 # Golang Build
 
-This Task is Golang task to build Go projects.
+This Task builds Go packages.
 
-### Parameters
+## Installation
 
-* **package**: base package under test
-* **packages**: packages to test (_default:_ ./...)
-* **version**: golang version to use for tests (_default:_ latest)
-* **flags**: flags to use for `go build` command (_default:_ -v)
-* **GOOS**: operating system target (_default:_ linux)
-* **GOARCH**: architecture target (_default:_ amd64)
-* **GO111MODULE**: value of module support (_default:_ auto)
-* **GOCACHE**: value for go caching path (_default:_ "")
-* **GOMODCACHE**: value for go module caching path (_default:_ "")
-* **CGO_ENABLED**: value for go cgo tool toggle (_default:_ "")
-* **GOSUMDB**: value for go checksum database url (_default:_ "")
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-build/golang-build.yaml
+```
 
-### Workspaces
+## Parameters
 
-* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `package` | Base package to build in | _(required)_ |
+| `packages` | Packages to build | `./cmd/...` |
+| `version` | Golang version to use for builds | `latest` |
+| `flags` | Flags to use for the build command | `-v` |
+| `GOOS` | Target operating system | `linux` |
+| `GOARCH` | Target architecture | `amd64` |
+| `GO111MODULE` | Value of module support | `auto` |
+| `GOCACHE` | Go caching directory path | `""` |
+| `GOMODCACHE` | Go mod caching directory path | `""` |
+| `CGO_ENABLED` | Toggle cgo tool during build. Use `0` to disable (for static builds). | `""` |
+| `GOSUMDB` | Go checksum database URL. Use `off` to disable checksum validation. | `""` |
 
-### Platforms
+## Workspaces
 
-The Task can be run on `linux/amd64`, `linux/s390x`,  and `linux/ppc64le` platforms.
+| Workspace | Description | Optional |
+|-----------|-------------|----------|
+| `source` | The Go source code to build | No |
 
-Specify value for `GOARCH` parameter according to the desired target architecture.
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+Set the `GOARCH` parameter according to the desired target architecture.
 
 ## Usage
 
-This TaskRun runs the Task to compile commands from
-[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline).
-
 ```yaml
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: build-my-code
@@ -40,10 +47,33 @@ spec:
   taskRef:
     name: golang-build
   workspaces:
-  - name: source
-    persistentVolumeClaim:
-      claimName: my-source
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
   params:
-  - name: package
-    value: github.com/tektoncd/pipeline
+    - name: package
+      value: github.com/tektoncd/pipeline
+```
+
+### Static binary build
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: build-static-binary
+spec:
+  taskRef:
+    name: golang-build
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: package
+      value: github.com/my-org/my-project
+    - name: flags
+      value: -v -ldflags="-s -w"
+    - name: CGO_ENABLED
+      value: "0"
 ```

--- a/task/golang-test/README.md
+++ b/task/golang-test/README.md
@@ -1,38 +1,46 @@
 # Golang Test
 
-This task is a Golang task to test Go projects.
+This Task runs Go tests.
 
-### Parameters
+## Installation
 
-* **package**: base package to build in
-* **packages**: packages to test (_default:_ ./cmd/...)
-* **context**: path to the directory to use as context (default: .)
-* **version**: golang version to use for builds (_default:_ latest)
-* **flags**: flags to use for `go test` command (_default:_ -race -cover -v)
-* **GOOS**: operating system target (_default:_ linux)
-* **GOARCH**: architecture target (_default:_ amd64)
-* **GO111MODULE**: value of module support (_default:_ auto)
-* **GOCACHE**: value for go caching path (_default:_ "")
-* **GOMODCACHE**: value for go module caching path (_default:_ "")
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-test/golang-test.yaml
+```
 
-### Workspaces
+## Parameters
 
-* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `package` | Base package under test | _(required)_ |
+| `packages` | Packages to test | `./...` |
+| `context` | Path to the directory to use as context | `.` |
+| `version` | Golang version to use for tests | `latest` |
+| `flags` | Flags to use for the test command | `-race -cover -v` |
+| `GOOS` | Target operating system | `linux` |
+| `GOARCH` | Target architecture | `amd64` |
+| `GO111MODULE` | Value of module support | `auto` |
+| `GOCACHE` | Go caching directory path | `""` |
+| `GOMODCACHE` | Go mod caching directory path | `""` |
+
+## Workspaces
+
+| Workspace | Description | Optional |
+|-----------|-------------|----------|
+| `source` | The Go source code to test | No |
 
 ## Platforms
 
-The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+The Task can be run on `linux/amd64`, `linux/s390x`, and `linux/ppc64le` platforms.
 
-Specify value for `GOARCH` parameter according to the desired target architecture.
-Do not use `-race` flag in `flags` parameter for `linux/s390x` platform.
+Set the `GOARCH` parameter according to the desired target architecture.
+
+> **Note**: Do not use the `-race` flag on `linux/s390x` — it is not supported on that platform.
 
 ## Usage
 
-This TaskRun runs the Task to run unit-tests on
-[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline).
-
 ```yaml
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: test-my-code
@@ -40,12 +48,33 @@ spec:
   taskRef:
     name: golang-test
   workspaces:
-  - name: source
-    persistentVolumeClaim:
-      claimName: my-source
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
   params:
-  - name: package
-    value: github.com/tektoncd/pipeline
-  - name: packages
-    value: ./pkg/...
+    - name: package
+      value: github.com/tektoncd/pipeline
+```
+
+### Test specific packages
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: test-specific-packages
+spec:
+  taskRef:
+    name: golang-test
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: package
+      value: github.com/tektoncd/pipeline
+    - name: packages
+      value: ./pkg/reconciler/...
+    - name: flags
+      value: -race -cover -v -count=1
 ```


### PR DESCRIPTION
## Changes

Rewrite the top-level README and per-task READMEs. The existing docs were a single line at the top level, and the task READMEs used `v1beta1` examples and bullet-list parameter docs.

### What changed:

**Top-level `README.md`:**
- Artifact Hub badge
- Task overview table
- Installation instructions
- Quick start examples for build, test, and a full pipeline (git-clone → build + test)
- Requirements section

**`task/golang-build/README.md`:**
- Installation command
- Parameter table (replacing bullet list)
- Workspace and platform tables
- Updated examples to `tekton.dev/v1`
- Added static binary build example

**`task/golang-test/README.md`:**
- Installation command
- Parameter table (replacing bullet list)
- Workspace and platform tables
- Updated examples to `tekton.dev/v1`
- Added "test specific packages" example
- Note about `-race` flag on s390x

## Release Notes

```release-note
NONE
```