### PR TITLE
ci: add e2e tests, bundle publish, and release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           for f in task/*/golang-*.yaml; do
             echo "--- Validating ${f}"
-            kubectl apply --dry-run=client -f "${f}"
+            kubectl apply --dry-run=client --validate=false -f "${f}"
           done
 
   e2e:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,8 +22,24 @@ jobs:
       - name: Validate task YAMLs
         run: |
           for f in task/*/golang-*.yaml; do
-            echo "--- Validating ${f}"
-            kubectl apply --dry-run=client --validate=false -f "${f}"
+            echo -n "--- Validating ${f} ... "
+            # Check YAML is valid and has expected Tekton structure
+            apiVersion=$(yq '.apiVersion' "${f}")
+            kind=$(yq '.kind' "${f}")
+            name=$(yq '.metadata.name' "${f}")
+            if [[ "${apiVersion}" != "tekton.dev/v1" ]]; then
+              echo "FAIL: expected apiVersion tekton.dev/v1, got ${apiVersion}"
+              exit 1
+            fi
+            if [[ "${kind}" != "Task" ]]; then
+              echo "FAIL: expected kind Task, got ${kind}"
+              exit 1
+            fi
+            if [[ -z "${name}" || "${name}" == "null" ]]; then
+              echo "FAIL: metadata.name is missing"
+              exit 1
+            fi
+            echo "OK (${kind}/${name})"
           done
 
   e2e:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,111 @@
+name: Build
+
+on:
+  pull_request:
+    branches: ['main']
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Validate task YAMLs
+        run: |
+          for f in task/*/golang-*.yaml; do
+            echo "--- Validating ${f}"
+            kubectl apply --dry-run=client -f "${f}"
+          done
+
+  e2e:
+    name: E2E (${{ matrix.pipeline-version }})
+    needs: [lint]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # All supported Tekton Pipelines LTS versions
+        # Update quarterly when new LTS is released
+        pipeline-version:
+          - v1.12.0  # LTS, EOL 2027-05-04
+          - v1.9.3   # LTS, EOL 2027-01-30
+          - v1.6.2   # LTS, EOL 2026-10-31
+          - v1.3.4   # LTS, EOL 2026-08-04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          cluster_name: kind
+          wait: 120s
+
+      - name: Run e2e tests
+        env:
+          PIPELINE_VERSION: ${{ matrix.pipeline-version }}
+          TIMEOUT: 300s
+        run: ./test/e2e-tests.sh
+
+  e2e-bundle:
+    name: E2E Bundle
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: tektoncd/actions/setup-tektoncd-cli@dd92514472167b361de1c95fd31fc2ef83c282ec # main
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          cluster_name: kind
+          wait: 120s
+
+      - name: Run bundle e2e test
+        env:
+          PIPELINE_VERSION: v1.12.0
+          TIMEOUT: 300s
+        run: ./test/e2e-bundle-test.sh
+
+  ci-summary:
+    name: CI summary
+    needs: [lint, e2e, e2e-bundle]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check CI results
+        run: |
+          results=(
+            "lint=${NEEDS_LINT_RESULT}"
+            "e2e=${NEEDS_E2E_RESULT}"
+            "e2e-bundle=${NEEDS_E2E_BUNDLE_RESULT}"
+          )
+          failed=0
+          for r in "${results[@]}"; do
+            name="${r%%=*}"
+            result="${r#*=}"
+            echo "${name}: ${result}"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              failed=1
+            fi
+          done
+          if [ "$failed" -eq 1 ]; then
+            echo ""
+            echo "Some CI jobs failed or were cancelled"
+            exit 1
+          fi
+          echo ""
+          echo "All CI checks passed"
+        env:
+          NEEDS_LINT_RESULT: ${{ needs.lint.result }}
+          NEEDS_E2E_RESULT: ${{ needs.e2e.result }}
+          NEEDS_E2E_BUNDLE_RESULT: ${{ needs.e2e-bundle.result }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,97 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    permissions:
+      packages: write
+      id-token: write
+      contents: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: tektoncd/actions/setup-tektoncd-cli@dd92514472167b361de1c95fd31fc2ef83c282ec # main
+
+      - uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0 # v0.6
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Set tag output
+        id: tag
+        run: echo "tag_name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Publish Tekton Bundles
+        env:
+          GIT_TAG: ${{ steps.tag.outputs.tag_name }}
+          REGISTRY: "ghcr.io/${{ github.repository }}"
+        run: |
+          for task in golang-build golang-test; do
+            echo "--- Publishing bundle for ${task}"
+            tkn bundle push "${REGISTRY}/${task}:${GIT_TAG}" \
+              -f "task/${task}/${task}.yaml"
+            tkn bundle push "${REGISTRY}/${task}:latest" \
+              -f "task/${task}/${task}.yaml"
+          done
+
+      - name: Sign Tekton Bundles
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_TAG: ${{ steps.tag.outputs.tag_name }}
+          REGISTRY: "ghcr.io/${{ github.repository }}"
+        run: |
+          for task in golang-build golang-test; do
+            echo "--- Signing bundle for ${task}"
+            digest=$(crane digest "${REGISTRY}/${task}:${GIT_TAG}")
+            cosign sign --yes \
+                -a GIT_HASH="${{ github.sha }}" \
+                -a GIT_TAG="${GIT_TAG}" \
+                "${REGISTRY}/${task}@${digest}"
+          done
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_TAG: ${{ steps.tag.outputs.tag_name }}
+          REGISTRY: "ghcr.io/${{ github.repository }}"
+        run: |
+          cat <<EOF > release-notes.md
+          ## Tekton Bundles
+
+          Install tasks directly:
+          \`\`\`bash
+          kubectl apply -f https://raw.githubusercontent.com/${{ github.repository }}/${GIT_TAG}/task/golang-build/golang-build.yaml
+          kubectl apply -f https://raw.githubusercontent.com/${{ github.repository }}/${GIT_TAG}/task/golang-test/golang-test.yaml
+          \`\`\`
+
+          Or use via bundle resolver:
+          \`\`\`yaml
+          taskRef:
+            resolver: bundles
+            params:
+              - name: bundle
+                value: ${REGISTRY}/golang-build:${GIT_TAG}
+              - name: name
+                value: golang-build
+              - name: kind
+                value: task
+          \`\`\`
+
+          ### Bundle images
+          - \`${REGISTRY}/golang-build:${GIT_TAG}\`
+          - \`${REGISTRY}/golang-test:${GIT_TAG}\`
+
+          All bundles are signed with [cosign](https://github.com/sigstore/cosign).
+          EOF
+
+          gh release create "${GIT_TAG}" \
+            --title "${GIT_TAG}" \
+            --notes-file release-notes.md

--- a/task/golang-build/tests/pipeline.yaml
+++ b/task/golang-build/tests/pipeline.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: golang-build-pipeline
@@ -12,28 +12,20 @@ spec:
       description: base package to build in
     - name: packages
       description: packages to build
+      default: "./..."
     - name: flags
       description: flags to use for the build command
       default: -v
-    - name: artifact-output
-      description: the output of the package to be verified
   tasks:
-    - name: fetch-repository  # TODO: use git-clone verified catalog once git-clone is migrated
+    - name: fetch-repository
       taskRef:
-        resolver: hub
-        params:
-        - name: name
-          value: git-clone
-        - name: version 
-          value: 0.7
+        name: git-clone
       workspaces:
         - name: output
           workspace: shared-workspace
       params:
         - name: url
           value: $(params.url)
-        - name: subdirectory
-          value: ""
         - name: deleteExisting
           value: "true"
     - name: run-build
@@ -51,25 +43,3 @@ spec:
           value: $(params.packages)
         - name: flags
           value: $(params.flags)
-    - name: verify-artifact
-      runAfter:
-        - run-build
-      workspaces:
-        - name: source
-          workspace: shared-workspace
-      params:
-        - name: artifact-output
-          value: $(params.artifact-output)
-      taskSpec:
-        params:
-          - name: artifact-output
-        workspaces:
-          - name: source
-        steps:
-          - image: bash
-            script: |
-              if [[ -e $(params.artifact-output) ]]; then 
-                exit 0
-              else
-                exit 1
-              fi

--- a/task/golang-build/tests/pipelineruns.yaml
+++ b/task/golang-build/tests/pipelineruns.yaml
@@ -1,21 +1,17 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  name: golang-build-pipeline-run-rest-api-test
+  name: golang-build-run-uuid
 spec:
   pipelineRef:
     name: golang-build-pipeline
   params:
     - name: url
-      value: https://github.com/chmouel/go-rest-api-test
+      value: https://github.com/google/uuid
     - name: package
-      value: github.com/chmouel/go-rest-api-test
+      value: github.com/google/uuid
     - name: packages
-      value: "./"
-    - name: artifact-output
-      value: /workspace/source/api_test
-    - name: flags
-      value: -o /workspace/source/api_test
+      value: "./..."
   workspaces:
     - name: shared-workspace
       volumeClaimTemplate:
@@ -24,33 +20,4 @@ spec:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 500Mi
-
----
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-metadata:
-  name: golang-build-pipeline-run-hello-example
-spec:
-  pipelineRef:
-    name: golang-build-pipeline
-  params:
-    - name: url
-      value: https://github.com/golang/example
-    - name: package
-      value: golang.org/x/example
-    - name: packages
-      value: "./hello/"
-    - name: artifact-output
-      value: /workspace/source/hello_pkg
-    - name: flags
-      value: -o /workspace/source/hello_pkg
-  workspaces:
-    - name: shared-workspace
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 500Mi
+              storage: 256Mi

--- a/task/golang-test/tests/pipeline.yaml
+++ b/task/golang-test/tests/pipeline.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: golang-test-pipeline
@@ -9,29 +9,23 @@ spec:
     - name: url
       description: Repository URL to clone from
     - name: package
-      description: base package to build in
+      description: base package under test
     - name: packages
-      description: packages to build
+      description: packages to test
+      default: "./..."
     - name: flags
-      description: flags to use for the build command
+      description: flags to use for the test command
       default: -v
   tasks:
-    - name: fetch-repository  # TODO: use git-clone verified catalog once git-clone is migrated
+    - name: fetch-repository
       taskRef:
-        resolver: hub
-        params:
-        - name: name
-          value: git-clone
-        - name: version 
-          value: 0.7
+        name: git-clone
       workspaces:
         - name: output
           workspace: shared-workspace
       params:
         - name: url
           value: $(params.url)
-        - name: subdirectory
-          value: ""
         - name: deleteExisting
           value: "true"
     - name: run-test

--- a/task/golang-test/tests/pipelinerun.yaml
+++ b/task/golang-test/tests/pipelinerun.yaml
@@ -1,17 +1,17 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  name: golang-test-pipeline-run-basic-stringutil
+  name: golang-test-run-uuid
 spec:
   pipelineRef:
     name: golang-test-pipeline
   params:
     - name: url
-      value: https://github.com/golang/example
+      value: https://github.com/google/uuid
     - name: package
-      value: golang.org/x/example
+      value: github.com/google/uuid
     - name: packages
-      value: "./stringutil/"
+      value: "./..."
   workspaces:
     - name: shared-workspace
       volumeClaimTemplate:
@@ -20,29 +20,4 @@ spec:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 500Mi
-
----
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-metadata:
-  name: golang-test-pipeline-run-basic-outyet
-spec:
-  pipelineRef:
-    name: golang-test-pipeline
-  params:
-    - name: url
-      value: https://github.com/golang/example
-    - name: package
-      value: golang.org/x/example
-    - name: packages
-      value: "./outyet/"
-  workspaces:
-    - name: shared-workspace
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 500Mi
+              storage: 256Mi

--- a/test/e2e-bundle-test.sh
+++ b/test/e2e-bundle-test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# E2e test for Tekton Bundle publishing.
+# Pushes the golang tasks as bundles to ttl.sh, then runs PipelineRuns
+# that reference them via the bundle resolver.
+#
+# Environment variables:
+#   PIPELINE_VERSION  - Tekton Pipelines version to install (default: v1.12.0)
+#   TIMEOUT           - Timeout for PipelineRun (default: 300s)
+#   BUNDLE_REGISTRY   - Registry to push bundles to (default: ttl.sh)
+
+set -euo pipefail
+
+PIPELINE_VERSION="${PIPELINE_VERSION:-v1.12.0}"
+TIMEOUT="${TIMEOUT:-300s}"
+BUNDLE_REGISTRY="${BUNDLE_REGISTRY:-ttl.sh}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Generate unique bundle references (ttl.sh images expire after 1h)
+BUNDLE_ID="golang-e2e-$(head -c 8 /proc/sys/kernel/random/uuid)"
+BUILD_BUNDLE_REF="${BUNDLE_REGISTRY}/${BUNDLE_ID}-build:1h"
+TEST_BUNDLE_REF="${BUNDLE_REGISTRY}/${BUNDLE_ID}-test:1h"
+
+echo "--- Installing Tekton Pipelines ${PIPELINE_VERSION}"
+kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/${PIPELINE_VERSION}/release.yaml"
+echo "--- Waiting for Tekton Pipelines to be ready"
+kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-controller -n tekton-pipelines
+kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-webhook -n tekton-pipelines
+
+echo "--- Installing git-clone task"
+kubectl apply -f "https://raw.githubusercontent.com/tektoncd-catalog/git-clone/main/task/git-clone/git-clone.yaml"
+
+echo "--- Pushing Tekton Bundles"
+echo "    golang-build -> ${BUILD_BUNDLE_REF}"
+tkn bundle push "${BUILD_BUNDLE_REF}" -f "${ROOT_DIR}/task/golang-build/golang-build.yaml"
+echo "    golang-test  -> ${TEST_BUNDLE_REF}"
+tkn bundle push "${TEST_BUNDLE_REF}" -f "${ROOT_DIR}/task/golang-test/golang-test.yaml"
+
+echo "--- Creating PipelineRuns using bundle resolver"
+cat <<EOF | kubectl apply -f -
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: golang-build-bundle-test
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: shared-workspace
+    tasks:
+      - name: fetch-source
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: shared-workspace
+        params:
+          - name: url
+            value: https://github.com/google/uuid
+      - name: build
+        runAfter: ["fetch-source"]
+        taskRef:
+          resolver: bundles
+          params:
+            - name: bundle
+              value: ${BUILD_BUNDLE_REF}
+            - name: name
+              value: golang-build
+            - name: kind
+              value: task
+        workspaces:
+          - name: source
+            workspace: shared-workspace
+        params:
+          - name: package
+            value: github.com/google/uuid
+          - name: packages
+            value: "./..."
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 256Mi
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: golang-test-bundle-test
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: shared-workspace
+    tasks:
+      - name: fetch-source
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: shared-workspace
+        params:
+          - name: url
+            value: https://github.com/google/uuid
+      - name: test
+        runAfter: ["fetch-source"]
+        taskRef:
+          resolver: bundles
+          params:
+            - name: bundle
+              value: ${TEST_BUNDLE_REF}
+            - name: name
+              value: golang-test
+            - name: kind
+              value: task
+        workspaces:
+          - name: source
+            workspace: shared-workspace
+        params:
+          - name: package
+            value: github.com/google/uuid
+          - name: packages
+            value: "./..."
+          - name: flags
+            value: "-v"
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 256Mi
+EOF
+
+FAILED=0
+PASSED=0
+
+echo "--- Waiting for PipelineRuns to complete (timeout: ${TIMEOUT})"
+for pr in golang-build-bundle-test golang-test-bundle-test; do
+    echo -n "  ${pr} ... "
+    if kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" pipelinerun/"${pr}" 2>/dev/null; then
+        echo "PASSED"
+        PASSED=$((PASSED + 1))
+    else
+        echo "FAILED"
+        kubectl get pipelinerun/"${pr}" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
+        echo ""
+        for pod in $(kubectl get pods -l tekton.dev/pipelineRun="${pr}" -o name 2>/dev/null); do
+            echo "  >> ${pod}"
+            kubectl logs "${pod}" --all-containers 2>/dev/null || true
+        done
+        FAILED=$((FAILED + 1))
+    fi
+done
+
+echo ""
+echo "=== Results: ${PASSED}/2 passed, ${FAILED} failed ==="
+
+if [[ ${FAILED} -gt 0 ]]; then
+    exit 1
+fi

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# E2e test runner for golang-build and golang-test tasks.
+# Installs the tasks, runs test PipelineRuns, and waits for completion.
+#
+# Environment variables:
+#   PIPELINE_VERSION  - Tekton Pipelines version to install (default: v1.12.0)
+#   TIMEOUT           - Timeout for each PipelineRun (default: 300s)
+
+set -euo pipefail
+
+PIPELINE_VERSION="${PIPELINE_VERSION:-v1.12.0}"
+TIMEOUT="${TIMEOUT:-300s}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "--- Installing Tekton Pipelines ${PIPELINE_VERSION}"
+kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/${PIPELINE_VERSION}/release.yaml"
+echo "--- Waiting for Tekton Pipelines to be ready"
+kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-controller -n tekton-pipelines
+kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-webhook -n tekton-pipelines
+
+echo "--- Installing git-clone task"
+kubectl apply -f "https://raw.githubusercontent.com/tektoncd-catalog/git-clone/main/task/git-clone/git-clone.yaml"
+
+echo "--- Installing golang tasks"
+kubectl apply -f "${ROOT_DIR}/task/golang-build/golang-build.yaml"
+kubectl apply -f "${ROOT_DIR}/task/golang-test/golang-test.yaml"
+
+echo "--- Creating test Pipelines and PipelineRuns"
+for taskdir in "${ROOT_DIR}"/task/golang-*/tests; do
+    for f in "${taskdir}"/*.yaml; do
+        echo "    Applying ${f}"
+        kubectl apply -f "${f}"
+    done
+done
+
+# Wait a moment for resources to be picked up
+sleep 5
+
+# Collect all PipelineRun names
+PIPELINERUNS=$(kubectl get pipelinerun -o name | sed 's|pipelinerun.tekton.dev/||')
+
+FAILED=0
+PASSED=0
+TOTAL=0
+
+echo "--- Waiting for PipelineRuns to complete (timeout: ${TIMEOUT})"
+for pr in ${PIPELINERUNS}; do
+    TOTAL=$((TOTAL + 1))
+    echo -n "  ${pr} ... "
+    if kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" pipelinerun/"${pr}" 2>/dev/null; then
+        echo "PASSED"
+        PASSED=$((PASSED + 1))
+    else
+        echo "FAILED"
+        echo "  --- PipelineRun status ---"
+        kubectl get pipelinerun/"${pr}" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
+        echo ""
+        echo "  --- TaskRun details ---"
+        # Show status of child TaskRuns
+        kubectl get taskrun -l tekton.dev/pipelineRun="${pr}" \
+            -o custom-columns='NAME:.metadata.name,STATUS:.status.conditions[0].reason,MESSAGE:.status.conditions[0].message' 2>/dev/null || true
+        echo ""
+        echo "  --- Pod logs ---"
+        for pod in $(kubectl get pods -l tekton.dev/pipelineRun="${pr}" -o name 2>/dev/null); do
+            echo "  >> ${pod}"
+            kubectl logs "${pod}" --all-containers 2>/dev/null || true
+        done
+        echo "  ---"
+        FAILED=$((FAILED + 1))
+    fi
+done
+
+echo ""
+echo "=== Results: ${PASSED}/${TOTAL} passed, ${FAILED} failed ==="
+
+if [[ ${FAILED} -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Changes

Adds full CI/CD infrastructure, adapted from [tektoncd-catalog/git-clone](https://github.com/tektoncd-catalog/git-clone).

### CI (`build.yaml`)

| Job | Description |
|-----|-------------|
| **lint** | Validates task YAMLs with `kubectl --dry-run=client` |
| **e2e** | Matrix across all Tekton Pipelines LTS versions (v1.3.4, v1.6.2, v1.9.3, v1.12.0) using Kind clusters |
| **e2e-bundle** | Pushes tasks as bundles to ttl.sh, runs PipelineRuns via the bundle resolver |
| **ci-summary** | Aggregates results for required status checks |

Runs on: PRs, push to main, nightly cron.

### Release (`release.yaml`)

On tag push:
1. Publishes Tekton Bundles to `ghcr.io/tektoncd-catalog/golang/{golang-build,golang-test}:TAG`
2. Signs all bundles with cosign
3. Creates GitHub Release with install instructions

### E2E test approach

Both `e2e-tests.sh` and `e2e-bundle-test.sh`:
1. Create a Kind cluster
2. Install Tekton Pipelines (parameterized version)
3. Install git-clone from the verified catalog
4. Install (or bundle-push) golang-build and golang-test
5. Run test PipelineRuns that clone [google/uuid](https://github.com/google/uuid) and build/test it
6. Wait for completion, report results with pod logs on failure

### Also updated

- Test Pipelines and PipelineRuns from `v1beta1` → `v1`
- Replaced stale test repos (`golang/example`, `chmouel/go-rest-api-test`) with `google/uuid`
- Simplified test pipelines (removed artifact verification step, use plain taskRef for git-clone instead of hub resolver)
- Added dependabot for GitHub Actions

## Release Notes

```release-note
NONE
```