### PR TITLE
Add release script

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Release script for tektoncd-catalog/golang.
+#
+# Usage:
+#   ./hack/release.sh v1.2.0              # bump, commit, tag, push
+#   ./hack/release.sh v1.2.0 --dry-run    # show what would change
+#   ./hack/release.sh v1.2.0 --llm        # generate changelog with gh copilot
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# --- Parse arguments ---
+VERSION=""
+DRY_RUN=false
+USE_LLM=false
+
+for arg in "$@"; do
+    case "${arg}" in
+        --dry-run) DRY_RUN=true ;;
+        --llm) USE_LLM=true ;;
+        v*) VERSION="${arg}" ;;
+        *) echo "Unknown argument: ${arg}"; exit 1 ;;
+    esac
+done
+
+if [[ -z "${VERSION}" ]]; then
+    echo "Usage: $0 <version> [--dry-run] [--llm]"
+    echo "  Example: $0 v1.2.0"
+    exit 1
+fi
+
+# Validate version format
+if ! echo "${VERSION}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "Error: version must match vX.Y.Z (got: ${VERSION})"
+    exit 1
+fi
+
+# Strip the 'v' prefix for places that need bare version
+BARE_VERSION="${VERSION#v}"
+
+cd "${ROOT_DIR}"
+
+# --- Task files to update ---
+TASK_FILES=(
+    "task/golang-build/golang-build.yaml"
+    "task/golang-test/golang-test.yaml"
+)
+
+# --- Detect current version from first task ---
+CURRENT_VERSION=$(grep 'app.kubernetes.io/version' "${TASK_FILES[0]}" | head -1 | sed 's/.*"\(.*\)"/\1/')
+CURRENT_TAG="v${CURRENT_VERSION}"
+
+echo "=== Release ${VERSION} ==="
+echo "  Current: ${CURRENT_TAG}"
+echo "  Target:  ${VERSION}"
+echo ""
+
+# --- Ensure we're on main and up to date (skip for dry-run) ---
+BRANCH=$(git branch --show-current)
+if [[ "${DRY_RUN}" != true ]]; then
+    if [[ "${BRANCH}" != "main" ]]; then
+        echo "Error: must be on main branch (currently on: ${BRANCH})"
+        exit 1
+    fi
+
+    git fetch origin main
+    LOCAL=$(git rev-parse HEAD)
+    REMOTE=$(git rev-parse origin/main)
+    if [[ "${LOCAL}" != "${REMOTE}" ]]; then
+        echo "Error: local main is not up to date with origin/main"
+        echo "  Local:  ${LOCAL}"
+        echo "  Remote: ${REMOTE}"
+        echo "  Run: git pull origin main"
+        exit 1
+    fi
+else
+    git fetch origin main 2>/dev/null || true
+fi
+
+# --- Generate changelog ---
+echo "--- Commits since ${CURRENT_TAG}:"
+COMMITS=$(git log --oneline "${CURRENT_TAG}..HEAD" --no-merges 2>/dev/null || git log --oneline -20)
+echo "${COMMITS}"
+echo ""
+
+if [[ "${USE_LLM}" == true ]]; then
+    echo "--- Generating changelog with gh copilot..."
+
+    PROMPT="Generate a release changelog for version ${VERSION} of the tektoncd-catalog/golang project (Tekton Tasks for building and testing Go projects).
+
+Here are the commits since the last release (${CURRENT_TAG}):
+
+${COMMITS}
+
+Output two sections:
+
+1. An artifacthub.io/changes YAML annotation block (indented with 6 spaces) with entries like:
+      - kind: added|changed|fixed|removed
+        description: Short one-line description
+
+2. A git tag annotation message with this format:
+Release ${VERSION}
+
+<category>:
+- <description>
+
+Use categories like Features, Fixes, Improvements, CI/Infra, Docs. Be concise.
+
+Output the two sections separated by the exact string ---SEPARATOR--- on its own line."
+
+    LLM_OUTPUT=$(gh copilot -p "${PROMPT}" 2>/dev/null || echo "")
+
+    if [[ -n "${LLM_OUTPUT}" ]]; then
+        AH_CHANGES=$(echo "${LLM_OUTPUT}" | sed -n '/^ *- kind:/,/---SEPARATOR---/p' | grep -v '^---SEPARATOR---')
+        TAG_MESSAGE=$(echo "${LLM_OUTPUT}" | sed -n '/^---SEPARATOR---$/,$ p' | tail -n +2 | sed '/^$/d; /^[[:space:]]*$/d' | sed '1{/^$/d}')
+    else
+        echo "Warning: gh copilot not available, falling back to git log"
+        USE_LLM=false
+    fi
+fi
+
+if [[ "${USE_LLM}" != true ]]; then
+    # Generate simple changelog from commit types
+    AH_CHANGES=""
+    while IFS= read -r line; do
+        msg="${line#* }"  # strip commit hash
+        case "${msg}" in
+            feat:*|feat\(*) AH_CHANGES="${AH_CHANGES}      - kind: added\n        description: ${msg#*: }\n" ;;
+            fix:*|fix\(*)   AH_CHANGES="${AH_CHANGES}      - kind: fixed\n        description: ${msg#*: }\n" ;;
+            chore:*|ci:*|build*) AH_CHANGES="${AH_CHANGES}      - kind: changed\n        description: ${msg#*: }\n" ;;
+            docs:*)         AH_CHANGES="${AH_CHANGES}      - kind: changed\n        description: ${msg#*: }\n" ;;
+            *)              AH_CHANGES="${AH_CHANGES}      - kind: changed\n        description: ${msg}\n" ;;
+        esac
+    done <<< "${COMMITS}"
+
+    TAG_MESSAGE="Release ${VERSION}
+
+Changes since ${CURRENT_TAG}:
+$(echo "${COMMITS}" | sed 's/^[a-f0-9]* /- /')"
+fi
+
+echo ""
+echo "--- Artifact Hub changelog:"
+echo -e "${AH_CHANGES}"
+echo ""
+echo "--- Tag message:"
+echo "${TAG_MESSAGE}"
+echo ""
+
+# --- All files to update ---
+ALL_FILES=("${TASK_FILES[@]}" "README.md")
+
+echo "--- Version bumps:"
+for f in "${ALL_FILES[@]}"; do
+    echo "  ${f}"
+done
+echo ""
+
+# --- Helper: apply version bumps to a file (stdout) ---
+apply_version_bumps() {
+    local f="$1"
+    sed \
+        -e "s|app.kubernetes.io/version: \"${CURRENT_VERSION}\"|app.kubernetes.io/version: \"${BARE_VERSION}\"|g" \
+        -e "s|ghcr.io/tektoncd-catalog/golang/golang-build:${CURRENT_TAG}|ghcr.io/tektoncd-catalog/golang/golang-build:${VERSION}|g" \
+        -e "s|ghcr.io/tektoncd-catalog/golang/golang-test:${CURRENT_TAG}|ghcr.io/tektoncd-catalog/golang/golang-test:${VERSION}|g" \
+        "${f}"
+}
+
+# --- Helper: update artifacthub changelog in content (stdin → stdout) ---
+apply_ah_changes() {
+    python3 -c "
+import re, sys
+content = sys.stdin.read()
+new_changes = '''    artifacthub.io/changes: |
+$(echo -e "${AH_CHANGES}")'''
+content = re.sub(
+    r'    artifacthub\.io/changes: \|\n(      .*\n)*',
+    new_changes.rstrip() + '\n',
+    content,
+)
+sys.stdout.write(content)
+"
+}
+
+if [[ "${DRY_RUN}" == true ]]; then
+    echo "--- Dry run: showing changes ---"
+
+    for f in "${ALL_FILES[@]}"; do
+        echo ""
+        echo "=== ${f} ==="
+        if [[ "${f}" == *".yaml" ]]; then
+            apply_version_bumps "${f}" | apply_ah_changes | diff -u "${f}" - || true
+        else
+            apply_version_bumps "${f}" | diff -u "${f}" - || true
+        fi
+    done
+    echo ""
+    echo "Dry run complete. Run without --dry-run to apply."
+    exit 0
+fi
+
+# --- Apply version bumps ---
+echo "--- Applying version bumps..."
+
+for f in "${ALL_FILES[@]}"; do
+    if [[ "${f}" == *".yaml" ]]; then
+        apply_version_bumps "${f}" | apply_ah_changes > "${f}.tmp" && mv "${f}.tmp" "${f}"
+    else
+        apply_version_bumps "${f}" > "${f}.tmp" && mv "${f}.tmp" "${f}"
+    fi
+done
+
+echo "--- Committing..."
+git add "${ALL_FILES[@]}"
+git commit --signoff --message "chore: bump version to ${VERSION}"
+
+echo "--- Pushing to main..."
+git push origin main:main
+
+echo "--- Tagging ${VERSION}..."
+git tag -a "${VERSION}" -m "${TAG_MESSAGE}"
+
+echo "--- Pushing tag..."
+git push origin "refs/tags/${VERSION}:refs/tags/${VERSION}"
+
+echo ""
+echo "=== Release ${VERSION} initiated ==="
+echo "  Monitor: gh run list --workflow=release.yaml --limit 1"
+echo "  View:    https://github.com/tektoncd-catalog/golang/releases/tag/${VERSION}"


### PR DESCRIPTION
## Changes

Add `hack/release.sh`, adapted from [tektoncd-catalog/git-clone](https://github.com/tektoncd-catalog/git-clone/blob/main/hack/release.sh).

### Usage

```bash
./hack/release.sh v1.2.0              # bump, commit, tag, push
./hack/release.sh v1.2.0 --dry-run    # preview changes
./hack/release.sh v1.2.0 --llm        # AI-generated changelog via gh copilot
```

### What it does

1. Validates version format (`vX.Y.Z`) and ensures you're on an up-to-date `main`
2. Generates changelog from `git log` since the last tag (or via `gh copilot --llm`)
3. Bumps `app.kubernetes.io/version` in both task YAMLs
4. Updates `artifacthub.io/changes` annotations with the changelog
5. Bumps bundle image references in README
6. Commits with `--signoff`, pushes to main, tags, pushes tag
7. The tag push triggers the release workflow (bundle publish + cosign + GitHub Release)

### Adaptations from git-clone

- Operates on two task files (`golang-build` + `golang-test`) instead of one
- Updates bundle refs for both tasks (`ghcr.io/.../golang-build:TAG`, `.../golang-test:TAG`)
- No goreleaser or image-specific version bumps (this repo has no Go binary)

## Release Notes

```release-note
NONE
```