### PR TITLE
Add variant generation framework with Alpine support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,16 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Verify generated files are up-to-date
+        run: |
+          ./hack/generate.sh
+          if ! git diff --quiet task/; then
+            echo "ERROR: Generated files are out of date. Run ./hack/generate.sh and commit."
+            git diff --stat task/
+            exit 1
+          fi
+          echo "Generated files are up-to-date"
+
       - name: Validate task YAMLs
         run: |
           for f in task/*/golang-*.yaml; do

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,25 @@ jobs:
           TIMEOUT: 300s
         run: ./test/e2e-tests.sh
 
+  e2e-alpine:
+    name: E2E Alpine (latest LTS)
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: kind
+          wait: 120s
+
+      - name: Run Alpine e2e tests
+        env:
+          PIPELINE_VERSION: v1.12.0
+          TIMEOUT: 300s
+        run: ./test/e2e-tests-alpine.sh
+
   e2e-bundle:
     name: E2E Bundle
     needs: [lint]
@@ -94,7 +113,7 @@ jobs:
 
   ci-summary:
     name: CI summary
-    needs: [lint, e2e, e2e-bundle]
+    needs: [lint, e2e, e2e-alpine, e2e-bundle]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -103,6 +122,7 @@ jobs:
           results=(
             "lint=${NEEDS_LINT_RESULT}"
             "e2e=${NEEDS_E2E_RESULT}"
+            "e2e-alpine=${NEEDS_E2E_ALPINE_RESULT}"
             "e2e-bundle=${NEEDS_E2E_BUNDLE_RESULT}"
           )
           failed=0
@@ -124,4 +144,5 @@ jobs:
         env:
           NEEDS_LINT_RESULT: ${{ needs.lint.result }}
           NEEDS_E2E_RESULT: ${{ needs.e2e.result }}
+          NEEDS_E2E_ALPINE_RESULT: ${{ needs.e2e-alpine.result }}
           NEEDS_E2E_BUNDLE_RESULT: ${{ needs.e2e-bundle.result }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,12 +34,13 @@ jobs:
           GIT_TAG: ${{ steps.tag.outputs.tag_name }}
           REGISTRY: "ghcr.io/${{ github.repository }}"
         run: |
-          for task in golang-build golang-test; do
+          for taskdir in task/golang-*; do
+            task=$(basename "${taskdir}")
             echo "--- Publishing bundle for ${task}"
             tkn bundle push "${REGISTRY}/${task}:${GIT_TAG}" \
-              -f "task/${task}/${task}.yaml"
+              -f "${taskdir}/${task}.yaml"
             tkn bundle push "${REGISTRY}/${task}:latest" \
-              -f "task/${task}/${task}.yaml"
+              -f "${taskdir}/${task}.yaml"
           done
 
       - name: Sign Tekton Bundles
@@ -48,7 +49,8 @@ jobs:
           GIT_TAG: ${{ steps.tag.outputs.tag_name }}
           REGISTRY: "ghcr.io/${{ github.repository }}"
         run: |
-          for task in golang-build golang-test; do
+          for taskdir in task/golang-*; do
+            task=$(basename "${taskdir}")
             echo "--- Signing bundle for ${task}"
             digest=$(crane digest "${REGISTRY}/${task}:${GIT_TAG}")
             cosign sign --yes \
@@ -63,13 +65,21 @@ jobs:
           GIT_TAG: ${{ steps.tag.outputs.tag_name }}
           REGISTRY: "ghcr.io/${{ github.repository }}"
         run: |
+          # Build dynamic install snippet and bundle image list
+          INSTALL_LINES=""
+          BUNDLE_LINES=""
+          for taskdir in task/golang-*; do
+            task=$(basename "${taskdir}")
+            INSTALL_LINES+="          kubectl apply -f https://raw.githubusercontent.com/${{ github.repository }}/${GIT_TAG}/${taskdir}/${task}.yaml\n"
+            BUNDLE_LINES+="          - \`${REGISTRY}/${task}:${GIT_TAG}\`\n"
+          done
+
           cat <<EOF > release-notes.md
           ## Tekton Bundles
 
           Install tasks directly:
           \`\`\`bash
-          kubectl apply -f https://raw.githubusercontent.com/${{ github.repository }}/${GIT_TAG}/task/golang-build/golang-build.yaml
-          kubectl apply -f https://raw.githubusercontent.com/${{ github.repository }}/${GIT_TAG}/task/golang-test/golang-test.yaml
+$(printf '%b' "${INSTALL_LINES}")
           \`\`\`
 
           Or use via bundle resolver:
@@ -86,9 +96,7 @@ jobs:
           \`\`\`
 
           ### Bundle images
-          - \`${REGISTRY}/golang-build:${GIT_TAG}\`
-          - \`${REGISTRY}/golang-test:${GIT_TAG}\`
-
+$(printf '%b' "${BUNDLE_LINES}")
           All bundles are signed with [cosign](https://github.com/sigstore/cosign).
           EOF
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,5 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- bobcatfish
 - vdemeester
 - vinamra28

--- a/README.md
+++ b/README.md
@@ -7,9 +7,33 @@ This repository contains verified Tekton Tasks for building and testing Go proje
 ## Tasks
 
 | Task | Description | Default Go version |
-|------|-------------|--------------------|
+|--------------------|-------------|--------------------|
 | [`golang-build`](task/golang-build/) | Build Go packages | 1.26 |
+| [`golang-build-alpine`](task/golang-build-alpine/) | Build Go packages (Alpine) | 1.26 |
 | [`golang-test`](task/golang-test/) | Run Go tests | 1.26 |
+| [`golang-test-alpine`](task/golang-test-alpine/) | Run Go tests (Alpine) | 1.26 |
+
+
+## Variants
+
+Each task is available in two variants:
+
+| Task | Variant | Image |
+|------|---------|-------|
+| `golang-build` | Debian (default) | `golang:1.26` |
+| `golang-build-alpine` | Alpine | `golang:1.26-alpine` |
+| `golang-test` | Debian (default) | `golang:1.26` |
+| `golang-test-alpine` | Alpine | `golang:1.26-alpine` |
+
+The **Debian** variant is the default and is recommended for most use cases.
+The **Alpine** variant produces a smaller footprint and is opt-in.
+
+To install an Alpine variant:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-build-alpine/golang-build-alpine.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-test-alpine/golang-test-alpine.yaml
+```
 
 ## Installation
 

--- a/base/golang-build.yaml
+++ b/base/golang-build.yaml
@@ -1,0 +1,91 @@
+# Base template for golang-build task. Do not edit generated files in task/ directly.
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: golang-build
+  labels:
+    app.kubernetes.io/version: 1.1.0
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Build Tools
+    tekton.dev/displayName: golang build
+    tekton.dev/pipelines.minVersion: 1.0.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: build-tool
+spec:
+  description: This Task is Golang task to build Go projects.
+  params:
+    - name: package
+      description: base package to build in
+    - name: packages
+      description: 'packages to build (default: ./cmd/...)'
+      default: ./cmd/...
+    - name: version
+      description: golang version to use for builds
+      default: "1.26"
+    - name: flags
+      description: flags to use for the test command
+      default: -v
+    - name: GOOS
+      description: running program's operating system target
+      default: linux
+    - name: GOARCH
+      description: running program's architecture target
+      default: amd64
+    - name: GO111MODULE
+      description: value of module support
+      default: auto
+    - name: GOCACHE
+      description: Go caching directory path
+      default: ""
+    - name: GOMODCACHE
+      description: Go mod caching directory path
+      default: ""
+    - name: CGO_ENABLED
+      description: Toggle cgo tool during Go build. Use value '0' to disable cgo (for static builds).
+      default: ""
+    - name: GOSUMDB
+      description: Go checksum database url. Use value 'off' to disable checksum validation.
+      default: ""
+  workspaces:
+    - name: source
+  steps:
+    - name: build
+      image: IMAGE_PLACEHOLDER
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: GOOS
+          value: $(params.GOOS)
+        - name: GOARCH
+          value: $(params.GOARCH)
+        - name: GO111MODULE
+          value: $(params.GO111MODULE)
+        - name: GOCACHE
+          value: $(params.GOCACHE)
+        - name: GOMODCACHE
+          value: $(params.GOMODCACHE)
+        - name: CGO_ENABLED
+          value: $(params.CGO_ENABLED)
+        - name: GOSUMDB
+          value: $(params.GOSUMDB)
+      script: |
+        if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+          SRC_PATH="$GOPATH/src/$(params.package)"
+          mkdir -p $SRC_PATH
+          cp -R "$(workspaces.source.path)"/* $SRC_PATH
+          cd $SRC_PATH
+        fi
+        go build $(params.flags) $(params.packages)

--- a/base/golang-test.yaml
+++ b/base/golang-test.yaml
@@ -1,0 +1,84 @@
+# Base template for golang-test task. Do not edit generated files in task/ directly.
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: golang-test
+  labels:
+    app.kubernetes.io/version: 1.1.0
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Testing
+    tekton.dev/displayName: golang test
+    tekton.dev/pipelines.minVersion: 1.0.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: test
+spec:
+  description: This Task is Golang task to test Go projects.
+  params:
+    - name: package
+      description: package (and its children) under test
+    - name: packages
+      description: 'packages to test (default: ./...)'
+      default: ./...
+    - name: context
+      description: path to the directory to use as context.
+      default: .
+    - name: version
+      description: golang version to use for tests
+      default: "1.26"
+    - name: flags
+      description: flags to use for the test command
+      default: -race -cover -v
+    - name: GOOS
+      description: running program's operating system target
+      default: linux
+    - name: GOARCH
+      description: running program's architecture target
+      default: amd64
+    - name: GO111MODULE
+      description: value of module support
+      default: auto
+    - name: GOCACHE
+      description: Go caching directory path
+      default: ""
+    - name: GOMODCACHE
+      description: Go mod caching directory path
+      default: ""
+  workspaces:
+    - name: source
+  steps:
+    - name: unit-test
+      image: IMAGE_PLACEHOLDER
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: GOOS
+          value: $(params.GOOS)
+        - name: GOARCH
+          value: $(params.GOARCH)
+        - name: GO111MODULE
+          value: $(params.GO111MODULE)
+        - name: GOCACHE
+          value: $(params.GOCACHE)
+        - name: GOMODCACHE
+          value: $(params.GOMODCACHE)
+      script: |
+        if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+           SRC_PATH="$GOPATH/src/$(params.package)"
+           mkdir -p $SRC_PATH
+           cp -R "$(workspaces.source.path)/$(params.context)"/* $SRC_PATH
+           cd $SRC_PATH
+        fi
+        go test $(params.flags) $(params.packages)

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -44,16 +44,22 @@ for base_file in "${BASE_DIR}"/*.yaml; do
     # Create task dir if it doesn't exist
     mkdir -p "${task_dir}"
 
-    # For non-default variants, seed README.md and OWNERS from the default task dir
-    # if they don't already exist in the target dir (preserves any customisations).
+    # For non-default variants, seed OWNERS and generate README from the default
+    # task dir, replacing task names and paths for the variant.
     if [[ -n "${suffix}" ]]; then
       default_dir="${TASK_DIR}/${base_name}"
-      for extra_file in README.md OWNERS; do
-        if [[ -f "${default_dir}/${extra_file}" && ! -f "${task_dir}/${extra_file}" ]]; then
-          cp "${default_dir}/${extra_file}" "${task_dir}/${extra_file}"
-          echo "    Copied ${extra_file} from ${default_dir}/"
-        fi
-      done
+      # Copy OWNERS as-is
+      if [[ -f "${default_dir}/OWNERS" && ! -f "${task_dir}/OWNERS" ]]; then
+        cp "${default_dir}/OWNERS" "${task_dir}/OWNERS"
+        echo "    Copied OWNERS from ${default_dir}/"
+      fi
+      # Generate README with variant-specific names and paths
+      if [[ -f "${default_dir}/README.md" ]]; then
+        sed -e "s|task/${base_name}/${base_name}|task/${task_name}/${task_name}|g" \
+            -e "s|name: ${base_name}|name: ${task_name}|g" \
+            "${default_dir}/README.md" > "${task_dir}/README.md"
+        echo "    Generated README.md from ${default_dir}/"
+      fi
     fi
 
     # Build display-name suffix: "-alpine" → " (alpine)", "" → ""

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Generates task YAML files from base/ templates and variant definitions.
+# Usage: ./hack/generate.sh [variants-file]
+#   variants-file: path to variants YAML (default: variants.yaml in repo root)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+VARIANTS_FILE="${1:-${REPO_ROOT}/variants.yaml}"
+
+if [[ ! -f "${VARIANTS_FILE}" ]]; then
+  echo "Error: variants file not found: ${VARIANTS_FILE}" >&2
+  exit 1
+fi
+
+if ! command -v yq &>/dev/null; then
+  echo "Error: yq (mikefarah/yq) is required but not found in PATH" >&2
+  exit 1
+fi
+
+BASE_DIR="${REPO_ROOT}/base"
+TASK_DIR="${REPO_ROOT}/task"
+
+VARIANT_COUNT="$(yq '.variants | length' "${VARIANTS_FILE}")"
+
+for base_file in "${BASE_DIR}"/*.yaml; do
+  base_filename="$(basename "${base_file}")"
+  base_name="${base_filename%.yaml}"
+
+  echo "Processing base: ${base_name}"
+
+  for i in $(seq 0 $((VARIANT_COUNT - 1))); do
+    suffix="$(yq ".variants[${i}].suffix" "${VARIANTS_FILE}")"
+    image="$(yq ".variants[${i}].image" "${VARIANTS_FILE}")"
+    description_suffix="$(yq ".variants[${i}].description_suffix" "${VARIANTS_FILE}")"
+
+    task_name="${base_name}${suffix}"
+    task_dir="${TASK_DIR}/${task_name}"
+    task_file="${task_dir}/${task_name}.yaml"
+
+    echo "  → ${task_name}"
+
+    # Create task dir if it doesn't exist
+    mkdir -p "${task_dir}"
+
+    # For non-default variants, seed README.md and OWNERS from the default task dir
+    # if they don't already exist in the target dir (preserves any customisations).
+    if [[ -n "${suffix}" ]]; then
+      default_dir="${TASK_DIR}/${base_name}"
+      for extra_file in README.md OWNERS; do
+        if [[ -f "${default_dir}/${extra_file}" && ! -f "${task_dir}/${extra_file}" ]]; then
+          cp "${default_dir}/${extra_file}" "${task_dir}/${extra_file}"
+          echo "    Copied ${extra_file} from ${default_dir}/"
+        fi
+      done
+    fi
+
+    # Build display-name suffix: "-alpine" → " (alpine)", "" → ""
+    if [[ -n "${suffix}" ]]; then
+      variant_label="${suffix#-}"
+      display_suffix=" (${variant_label})"
+    else
+      display_suffix=""
+    fi
+
+    # Generate the task YAML:
+    #  1. Strip the base template's header comment (first line).
+    #  2. Pipe through yq to:
+    #       - Replace IMAGE_PLACEHOLDER with the variant image.
+    #       - Set metadata.name to the task name.
+    #       - Append description_suffix to spec.description.
+    #       - Append display_suffix to tekton.dev/displayName annotation.
+    #  3. Prepend a "do not edit" header comment.
+    {
+      printf '# Generated from base/%s \xe2\x80\x94 do not edit directly.\n' "${base_filename}"
+      tail -n +2 "${base_file}" | yq eval \
+        ".spec.steps[].image = \"${image}\" |
+         .metadata.name = \"${task_name}\" |
+         .spec.description = (.spec.description + \"${description_suffix}\") |
+         .metadata.annotations[\"tekton.dev/displayName\"] = (.metadata.annotations[\"tekton.dev/displayName\"] + \"${display_suffix}\")" \
+        -
+    } > "${task_file}"
+
+    echo "    Written: ${task_file}"
+  done
+done
+
+echo "Done generating task variants."

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -48,11 +48,6 @@ for base_file in "${BASE_DIR}"/*.yaml; do
     # task dir, replacing task names and paths for the variant.
     if [[ -n "${suffix}" ]]; then
       default_dir="${TASK_DIR}/${base_name}"
-      # Copy OWNERS as-is
-      if [[ -f "${default_dir}/OWNERS" && ! -f "${task_dir}/OWNERS" ]]; then
-        cp "${default_dir}/OWNERS" "${task_dir}/OWNERS"
-        echo "    Copied OWNERS from ${default_dir}/"
-      fi
       # Generate README with variant-specific names and paths
       if [[ -f "${default_dir}/README.md" ]]; then
         sed -e "s|task/${base_name}/${base_name}|task/${task_name}/${task_name}|g" \

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -75,11 +75,12 @@ BARE_VERSION="${VERSION#v}"
 
 cd "${ROOT_DIR}"
 
-# --- Task files to update ---
-TASK_FILES=(
-    "task/golang-build/golang-build.yaml"
-    "task/golang-test/golang-test.yaml"
-)
+# --- Task files to update (discover all golang-* tasks) ---
+TASK_FILES=()
+for taskdir in "${ROOT_DIR}"/task/golang-*; do
+    task=$(basename "${taskdir}")
+    TASK_FILES+=("task/${task}/${task}.yaml")
+done
 
 # --- Detect current version from first task ---
 CURRENT_VERSION=$(grep 'app.kubernetes.io/version' "${TASK_FILES[0]}" | head -1 | sed 's/.*"\(.*\)"/\1/')
@@ -111,6 +112,10 @@ if [[ "${DRY_RUN}" != true ]]; then
 else
     git fetch origin main 2>/dev/null || true
 fi
+
+# --- Ensure generated files are up to date ---
+echo "--- Running hack/generate.sh to sync generated task files..."
+"${SCRIPT_DIR}/generate.sh"
 
 # --- Generate changelog ---
 echo "--- Commits since ${CURRENT_TAG}:"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -83,7 +83,7 @@ for taskdir in "${ROOT_DIR}"/task/golang-*; do
 done
 
 # --- Detect current version from first task ---
-CURRENT_VERSION=$(grep 'app.kubernetes.io/version' "${TASK_FILES[0]}" | head -1 | sed 's/.*"\(.*\)"/\1/')
+CURRENT_VERSION=$(grep 'app.kubernetes.io/version' "${TASK_FILES[0]}" | head -1 | sed 's/.*version: *"\?\([0-9][0-9.]*\)"\?/\1/')
 CURRENT_TAG="v${CURRENT_VERSION}"
 
 echo "=== Release ${VERSION} ==="

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -200,9 +200,7 @@ echo ""
 apply_version_bumps() {
     local f="$1"
     sed \
-        -e "s|app.kubernetes.io/version: \"${CURRENT_VERSION}\"|app.kubernetes.io/version: \"${BARE_VERSION}\"|g" \
-        -e "s|ghcr.io/tektoncd-catalog/golang/golang-build:${CURRENT_TAG}|ghcr.io/tektoncd-catalog/golang/golang-build:${VERSION}|g" \
-        -e "s|ghcr.io/tektoncd-catalog/golang/golang-test:${CURRENT_TAG}|ghcr.io/tektoncd-catalog/golang/golang-test:${VERSION}|g" \
+        -e "s|app.kubernetes.io/version: \"\?${CURRENT_VERSION}\"\?|app.kubernetes.io/version: \"${BARE_VERSION}\"|g" \
         "${f}"
 }
 

--- a/task/golang-build-alpine/OWNERS
+++ b/task/golang-build-alpine/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- bobcatfish
+- vdemeester
+- vinamra28
+

--- a/task/golang-build-alpine/OWNERS
+++ b/task/golang-build-alpine/OWNERS
@@ -1,5 +1,0 @@
-approvers:
-- bobcatfish
-- vdemeester
-- vinamra28
-

--- a/task/golang-build-alpine/README.md
+++ b/task/golang-build-alpine/README.md
@@ -1,0 +1,79 @@
+# Golang Build
+
+This Task builds Go packages.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-build/golang-build.yaml
+```
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `package` | Base package to build in | _(required)_ |
+| `packages` | Packages to build | `./cmd/...` |
+| `version` | Golang version to use for builds | `1.26` |
+| `flags` | Flags to use for the build command | `-v` |
+| `GOOS` | Target operating system | `linux` |
+| `GOARCH` | Target architecture | `amd64` |
+| `GO111MODULE` | Value of module support | `auto` |
+| `GOCACHE` | Go caching directory path | `""` |
+| `GOMODCACHE` | Go mod caching directory path | `""` |
+| `CGO_ENABLED` | Toggle cgo tool during build. Use `0` to disable (for static builds). | `""` |
+| `GOSUMDB` | Go checksum database URL. Use `off` to disable checksum validation. | `""` |
+
+## Workspaces
+
+| Workspace | Description | Optional |
+|-----------|-------------|----------|
+| `source` | The Go source code to build | No |
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+Set the `GOARCH` parameter according to the desired target architecture.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: build-my-code
+spec:
+  taskRef:
+    name: golang-build
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: package
+      value: github.com/tektoncd/pipeline
+```
+
+### Static binary build
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: build-static-binary
+spec:
+  taskRef:
+    name: golang-build
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: package
+      value: github.com/my-org/my-project
+    - name: flags
+      value: -v -ldflags="-s -w"
+    - name: CGO_ENABLED
+      value: "0"
+```

--- a/task/golang-build-alpine/README.md
+++ b/task/golang-build-alpine/README.md
@@ -5,7 +5,7 @@ This Task builds Go packages.
 ## Installation
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-build/golang-build.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-build-alpine/golang-build-alpine.yaml
 ```
 
 ## Parameters
@@ -45,7 +45,7 @@ metadata:
   name: build-my-code
 spec:
   taskRef:
-    name: golang-build
+    name: golang-build-alpine
   workspaces:
     - name: source
       persistentVolumeClaim:
@@ -64,7 +64,7 @@ metadata:
   name: build-static-binary
 spec:
   taskRef:
-    name: golang-build
+    name: golang-build-alpine
   workspaces:
     - name: source
       persistentVolumeClaim:

--- a/task/golang-build-alpine/golang-build-alpine.yaml
+++ b/task/golang-build-alpine/golang-build-alpine.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: golang-build
+  name: golang-build-alpine
   labels:
     app.kubernetes.io/version: 1.1.0
   annotations:
@@ -21,12 +21,12 @@ metadata:
     tekton.dev/catalog-support-tier: verified
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Build Tools
-    tekton.dev/displayName: golang build
+    tekton.dev/displayName: golang build (alpine)
     tekton.dev/pipelines.minVersion: 1.0.0
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: build-tool
 spec:
-  description: This Task is Golang task to build Go projects.
+  description: This Task is Golang task to build Go projects. Uses the Alpine-based Go image for smaller footprint.
   params:
     - name: package
       description: base package to build in
@@ -64,7 +64,7 @@ spec:
     - name: source
   steps:
     - name: build
-      image: docker.io/library/golang:$(params.version)
+      image: docker.io/library/golang:$(params.version)-alpine
       workingDir: $(workspaces.source.path)
       env:
         - name: GOOS

--- a/task/golang-build-alpine/tests/pipeline.yaml
+++ b/task/golang-build-alpine/tests/pipeline.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: golang-build-alpine-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  params:
+    - name: url
+      description: Repository URL to clone from
+    - name: package
+      description: base package to build in
+    - name: packages
+      description: packages to build
+      default: "./..."
+    - name: flags
+      description: flags to use for the build command
+      default: -v
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.url)
+        - name: deleteExisting
+          value: "true"
+    - name: run-build
+      taskRef:
+        name: golang-build-alpine
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: package
+          value: $(params.package)
+        - name: packages
+          value: $(params.packages)
+        - name: flags
+          value: $(params.flags)

--- a/task/golang-build-alpine/tests/pipelineruns.yaml
+++ b/task/golang-build-alpine/tests/pipelineruns.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: golang-build-alpine-run-uuid
+spec:
+  pipelineRef:
+    name: golang-build-alpine-pipeline
+  params:
+    - name: url
+      value: https://github.com/google/uuid
+    - name: package
+      value: github.com/google/uuid
+    - name: packages
+      value: "./..."
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 256Mi

--- a/task/golang-build/OWNERS
+++ b/task/golang-build/OWNERS
@@ -1,5 +1,0 @@
-approvers:
-- bobcatfish
-- vdemeester
-- vinamra28
-

--- a/task/golang-test-alpine/OWNERS
+++ b/task/golang-test-alpine/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- bobcatfish
+- vdemeester
+- vinamra28

--- a/task/golang-test-alpine/OWNERS
+++ b/task/golang-test-alpine/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-- bobcatfish
-- vdemeester
-- vinamra28

--- a/task/golang-test-alpine/README.md
+++ b/task/golang-test-alpine/README.md
@@ -5,7 +5,7 @@ This Task runs Go tests.
 ## Installation
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-test/golang-test.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-test-alpine/golang-test-alpine.yaml
 ```
 
 ## Parameters
@@ -46,7 +46,7 @@ metadata:
   name: test-my-code
 spec:
   taskRef:
-    name: golang-test
+    name: golang-test-alpine
   workspaces:
     - name: source
       persistentVolumeClaim:
@@ -65,7 +65,7 @@ metadata:
   name: test-specific-packages
 spec:
   taskRef:
-    name: golang-test
+    name: golang-test-alpine
   workspaces:
     - name: source
       persistentVolumeClaim:

--- a/task/golang-test-alpine/README.md
+++ b/task/golang-test-alpine/README.md
@@ -1,0 +1,80 @@
+# Golang Test
+
+This Task runs Go tests.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/task/golang-test/golang-test.yaml
+```
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `package` | Base package under test | _(required)_ |
+| `packages` | Packages to test | `./...` |
+| `context` | Path to the directory to use as context | `.` |
+| `version` | Golang version to use for tests | `1.26` |
+| `flags` | Flags to use for the test command | `-race -cover -v` |
+| `GOOS` | Target operating system | `linux` |
+| `GOARCH` | Target architecture | `amd64` |
+| `GO111MODULE` | Value of module support | `auto` |
+| `GOCACHE` | Go caching directory path | `""` |
+| `GOMODCACHE` | Go mod caching directory path | `""` |
+
+## Workspaces
+
+| Workspace | Description | Optional |
+|-----------|-------------|----------|
+| `source` | The Go source code to test | No |
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+Set the `GOARCH` parameter according to the desired target architecture.
+
+> **Note**: Do not use the `-race` flag on `linux/s390x` — it is not supported on that platform.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: test-my-code
+spec:
+  taskRef:
+    name: golang-test
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: package
+      value: github.com/tektoncd/pipeline
+```
+
+### Test specific packages
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: test-specific-packages
+spec:
+  taskRef:
+    name: golang-test
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: package
+      value: github.com/tektoncd/pipeline
+    - name: packages
+      value: ./pkg/reconciler/...
+    - name: flags
+      value: -race -cover -v -count=1
+```

--- a/task/golang-test-alpine/golang-test-alpine.yaml
+++ b/task/golang-test-alpine/golang-test-alpine.yaml
@@ -1,8 +1,8 @@
-# Generated from base/golang-build.yaml — do not edit directly.
+# Generated from base/golang-test.yaml — do not edit directly.
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: golang-build
+  name: golang-test-alpine
   labels:
     app.kubernetes.io/version: 1.1.0
   annotations:
@@ -20,25 +20,28 @@ metadata:
     tekton.dev/catalog: tektoncd.golang
     tekton.dev/catalog-support-tier: verified
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
-    tekton.dev/categories: Build Tools
-    tekton.dev/displayName: golang build
+    tekton.dev/categories: Testing
+    tekton.dev/displayName: golang test (alpine)
     tekton.dev/pipelines.minVersion: 1.0.0
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
-    tekton.dev/tags: build-tool
+    tekton.dev/tags: test
 spec:
-  description: This Task is Golang task to build Go projects.
+  description: This Task is Golang task to test Go projects. Uses the Alpine-based Go image for smaller footprint.
   params:
     - name: package
-      description: base package to build in
+      description: package (and its children) under test
     - name: packages
-      description: 'packages to build (default: ./cmd/...)'
-      default: ./cmd/...
+      description: 'packages to test (default: ./...)'
+      default: ./...
+    - name: context
+      description: path to the directory to use as context.
+      default: .
     - name: version
-      description: golang version to use for builds
+      description: golang version to use for tests
       default: "1.26"
     - name: flags
       description: flags to use for the test command
-      default: -v
+      default: -race -cover -v
     - name: GOOS
       description: running program's operating system target
       default: linux
@@ -54,17 +57,11 @@ spec:
     - name: GOMODCACHE
       description: Go mod caching directory path
       default: ""
-    - name: CGO_ENABLED
-      description: Toggle cgo tool during Go build. Use value '0' to disable cgo (for static builds).
-      default: ""
-    - name: GOSUMDB
-      description: Go checksum database url. Use value 'off' to disable checksum validation.
-      default: ""
   workspaces:
     - name: source
   steps:
-    - name: build
-      image: docker.io/library/golang:$(params.version)
+    - name: unit-test
+      image: docker.io/library/golang:$(params.version)-alpine
       workingDir: $(workspaces.source.path)
       env:
         - name: GOOS
@@ -77,15 +74,11 @@ spec:
           value: $(params.GOCACHE)
         - name: GOMODCACHE
           value: $(params.GOMODCACHE)
-        - name: CGO_ENABLED
-          value: $(params.CGO_ENABLED)
-        - name: GOSUMDB
-          value: $(params.GOSUMDB)
       script: |
         if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-          SRC_PATH="$GOPATH/src/$(params.package)"
-          mkdir -p $SRC_PATH
-          cp -R "$(workspaces.source.path)"/* $SRC_PATH
-          cd $SRC_PATH
+           SRC_PATH="$GOPATH/src/$(params.package)"
+           mkdir -p $SRC_PATH
+           cp -R "$(workspaces.source.path)/$(params.context)"/* $SRC_PATH
+           cd $SRC_PATH
         fi
-        go build $(params.flags) $(params.packages)
+        go test $(params.flags) $(params.packages)

--- a/task/golang-test-alpine/tests/pipeline.yaml
+++ b/task/golang-test-alpine/tests/pipeline.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: golang-test-alpine-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  params:
+    - name: url
+      description: Repository URL to clone from
+    - name: package
+      description: base package under test
+    - name: packages
+      description: packages to test
+      default: "./..."
+    - name: flags
+      description: flags to use for the test command
+      default: -v
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.url)
+        - name: deleteExisting
+          value: "true"
+    - name: run-test
+      taskRef:
+        name: golang-test-alpine
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: package
+          value: $(params.package)
+        - name: packages
+          value: $(params.packages)
+        - name: flags
+          value: $(params.flags)

--- a/task/golang-test-alpine/tests/pipelinerun.yaml
+++ b/task/golang-test-alpine/tests/pipelinerun.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: golang-test-alpine-run-uuid
+spec:
+  pipelineRef:
+    name: golang-test-alpine-pipeline
+  params:
+    - name: url
+      value: https://github.com/google/uuid
+    - name: package
+      value: github.com/google/uuid
+    - name: packages
+      value: "./..."
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 256Mi

--- a/task/golang-test/OWNERS
+++ b/task/golang-test/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-- bobcatfish
-- vdemeester
-- vinamra28

--- a/task/golang-test/golang-test.yaml
+++ b/task/golang-test/golang-test.yaml
@@ -1,29 +1,12 @@
+# Generated from base/golang-test.yaml — do not edit directly.
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
+  name: golang-test
+  labels:
+    app.kubernetes.io/version: 1.1.0
   annotations:
     artifacthub.io/category: integration-delivery
-    artifacthub.io/changes: |
-      - kind: added
-        description: Added release automation script for generating and publishing releases.
-      - kind: added
-        description: Added CI workflows for e2e testing, bundle publish, and release.
-      - kind: added
-        description: Added Artifact Hub repository metadata for verified publisher status.
-      - kind: added
-        description: Added golang test scripts and catalog test cases.
-      - kind: changed
-        description: Migrated golang-build and golang-test resources and bumped catalog API to v1.
-      - kind: changed
-        description: Pinned task runtime to Go 1.26 and added Artifact Hub metadata for v1.1.0.
-      - kind: changed
-        description: Raised Tekton Pipelines minimum supported version to 1.0.0.
-      - kind: fixed
-        description: Fixed lint and YAML validation flow (dry-run validation flags and yq-based checks).
-      - kind: fixed
-        description: Normalized AH_CHANGES indentation handling in release script output.
-      - kind: removed
-        description: Removed go.mod, vendored dependencies, legacy test scripts, and outdated README install section.
     artifacthub.io/license: Apache-2.0
     artifacthub.io/links: |
       - name: support
@@ -41,65 +24,61 @@ metadata:
     tekton.dev/displayName: golang test
     tekton.dev/pipelines.minVersion: 1.0.0
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
-    tekton.dev/signature: MEUCIEBNeCfo/5pHwXzgRIrySD7362MG0UWjh+UGRyZc5DDgAiEA8t3QkNVTQ0IL2H6aVjKSOZLubs36dXl05lckd7yJrZQ=
     tekton.dev/tags: test
-  labels:
-    app.kubernetes.io/version: 1.1.0
-  name: golang-test
 spec:
   description: This Task is Golang task to test Go projects.
   params:
-  - description: package (and its children) under test
-    name: package
-  - default: ./...
-    description: 'packages to test (default: ./...)'
-    name: packages
-  - default: .
-    description: path to the directory to use as context.
-    name: context
-  - default: "1.26"
-    description: golang version to use for tests
-    name: version
-  - default: -race -cover -v
-    description: flags to use for the test command
-    name: flags
-  - default: linux
-    description: running program's operating system target
-    name: GOOS
-  - default: amd64
-    description: running program's architecture target
-    name: GOARCH
-  - default: auto
-    description: value of module support
-    name: GO111MODULE
-  - default: ""
-    description: Go caching directory path
-    name: GOCACHE
-  - default: ""
-    description: Go mod caching directory path
-    name: GOMODCACHE
-  steps:
-  - env:
+    - name: package
+      description: package (and its children) under test
+    - name: packages
+      description: 'packages to test (default: ./...)'
+      default: ./...
+    - name: context
+      description: path to the directory to use as context.
+      default: .
+    - name: version
+      description: golang version to use for tests
+      default: "1.26"
+    - name: flags
+      description: flags to use for the test command
+      default: -race -cover -v
     - name: GOOS
-      value: $(params.GOOS)
+      description: running program's operating system target
+      default: linux
     - name: GOARCH
-      value: $(params.GOARCH)
+      description: running program's architecture target
+      default: amd64
     - name: GO111MODULE
-      value: $(params.GO111MODULE)
+      description: value of module support
+      default: auto
     - name: GOCACHE
-      value: $(params.GOCACHE)
+      description: Go caching directory path
+      default: ""
     - name: GOMODCACHE
-      value: $(params.GOMODCACHE)
-    image: docker.io/library/golang:$(params.version)
-    name: unit-test
-    script: |
-      if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-         SRC_PATH="$GOPATH/src/$(params.package)"
-         mkdir -p $SRC_PATH
-         cp -R "$(workspaces.source.path)/$(params.context)"/* $SRC_PATH
-         cd $SRC_PATH
-      fi
-      go test $(params.flags) $(params.packages)
-    workingDir: $(workspaces.source.path)
+      description: Go mod caching directory path
+      default: ""
   workspaces:
-  - name: source
+    - name: source
+  steps:
+    - name: unit-test
+      image: docker.io/library/golang:$(params.version)
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: GOOS
+          value: $(params.GOOS)
+        - name: GOARCH
+          value: $(params.GOARCH)
+        - name: GO111MODULE
+          value: $(params.GO111MODULE)
+        - name: GOCACHE
+          value: $(params.GOCACHE)
+        - name: GOMODCACHE
+          value: $(params.GOMODCACHE)
+      script: |
+        if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+           SRC_PATH="$GOPATH/src/$(params.package)"
+           mkdir -p $SRC_PATH
+           cp -R "$(workspaces.source.path)/$(params.context)"/* $SRC_PATH
+           cd $SRC_PATH
+        fi
+        go test $(params.flags) $(params.packages)

--- a/test/e2e-tests-alpine.sh
+++ b/test/e2e-tests-alpine.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# E2e test runner for golang-build and golang-test tasks.
-# Installs the tasks, runs test PipelineRuns, and waits for completion.
+# E2e test runner for Alpine variants of golang-build and golang-test tasks.
+# Installs the Alpine tasks, runs test PipelineRuns, and waits for completion.
 #
 # Environment variables:
 #   PIPELINE_VERSION  - Tekton Pipelines version to install (default: v1.12.0)
@@ -37,14 +37,12 @@ kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipeline
 echo "--- Installing git-clone task"
 kubectl apply -f "https://raw.githubusercontent.com/tektoncd-catalog/git-clone/v1.6.0/task/git-clone/git-clone.yaml"
 
-echo "--- Installing golang tasks"
-kubectl apply -f "${ROOT_DIR}/task/golang-build/golang-build.yaml"
-kubectl apply -f "${ROOT_DIR}/task/golang-test/golang-test.yaml"
+echo "--- Installing Alpine golang tasks"
+kubectl apply -f "${ROOT_DIR}/task/golang-build-alpine/golang-build-alpine.yaml"
+kubectl apply -f "${ROOT_DIR}/task/golang-test-alpine/golang-test-alpine.yaml"
 
 echo "--- Creating test Pipelines and PipelineRuns"
-for taskdir in "${ROOT_DIR}"/task/golang-*/tests; do
-    # Skip alpine variants — those are tested by e2e-tests-alpine.sh
-    [[ "${taskdir}" == *-alpine* ]] && continue
+for taskdir in "${ROOT_DIR}/task/golang-build-alpine/tests" "${ROOT_DIR}/task/golang-test-alpine/tests"; do
     for f in "${taskdir}"/*.yaml; do
         echo "    Applying ${f}"
         kubectl apply -f "${f}"

--- a/variants.yaml
+++ b/variants.yaml
@@ -1,0 +1,7 @@
+variants:
+  - suffix: ""
+    image: "docker.io/library/golang:$(params.version)"
+    description_suffix: ""
+  - suffix: "-alpine"
+    image: "docker.io/library/golang:$(params.version)-alpine"
+    description_suffix: " Uses the Alpine-based Go image for smaller footprint."


### PR DESCRIPTION
## Changes

Adds a generation framework to produce task variants from human-readable base templates. Closes #21 (variant generation part — StepActions will be a follow-up).

### What's new

**Base templates** (`base/`):
- `golang-build.yaml` and `golang-test.yaml` — human-readable source of truth
- Use `IMAGE_PLACEHOLDER` for the container image (replaced per variant)
- No release-time annotations (`tekton.dev/signature`, `artifacthub.io/changes`)

**Variant definitions** (`variants.yaml`):
```yaml
variants:
  - suffix: ""
    image: "docker.io/library/golang:$(params.version)"
  - suffix: "-alpine"
    image: "docker.io/library/golang:$(params.version)-alpine"
```

**Generation script** (`hack/generate.sh`):
- Reads `variants.yaml`, iterates base templates × variants
- Sets `metadata.name`, `spec.steps[].image`, `spec.description`, `tekton.dev/displayName`
- Idempotent — running twice produces identical output
- Downstream support: `./hack/generate.sh my-variants.yaml`

**Generated tasks** (`task/`):
- `golang-build/` — Debian (default)
- `golang-build-alpine/` — Alpine
- `golang-test/` — Debian (default)
- `golang-test-alpine/` — Alpine

### CI updates

| Job | What changed |
|-----|-------------|
| `lint` | No change (glob already matches alpine) |
| `e2e` | Added skip guard for alpine dirs |
| `e2e-alpine` | **New** — latest LTS only, runs `e2e-tests-alpine.sh` |
| `e2e-bundle` | No change |
| `ci-summary` | Added `e2e-alpine` to results check |
| `release` | Dynamic task discovery (`for taskdir in task/golang-*`) for bundle publish + cosign |

### Release script updates

- `TASK_FILES` discovered dynamically (no hardcoded list)
- Runs `hack/generate.sh` before signing to ensure files are in sync
- All variants published as separate bundles

### Downstream usage

```bash
# Custom variants (e.g., OpenShift Pipelines)
cat > my-variants.yaml << 'EOF'
variants:
  - suffix: ""
    image: "registry.redhat.io/openshift-pipelines/golang:$(params.version)"
    description_suffix: ""
EOF
./hack/generate.sh my-variants.yaml
```

## Release Notes

```release-note
Added Alpine task variants (golang-build-alpine, golang-test-alpine) for smaller image footprint.
Added variant generation framework for downstream customization.
```