### PR TITLE
feat: StepActions and StepAction-only Go tools (#27)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,11 +22,11 @@ jobs:
       - name: Verify generated files are up-to-date
         run: |
           ./hack/generate.sh
-          # Compare committed vs freshly-generated task files. Ignore the
+          # Compare committed vs freshly-generated files. Ignore the
           # tekton.dev/signature annotation and key ordering, which release-time
-          # signing may introduce (yq -P sorts keys, normalizing any reorder).
+          # signing may introduce (sort_keys normalizes any reorder).
           status=0
-          for f in $(git diff --name-only task/); do
+          for f in $(git diff --name-only task/ stepaction/); do
             if [[ "${f}" != *.yaml ]]; then
               echo "ERROR: ${f} is out of date. Run ./hack/generate.sh and commit."
               status=1
@@ -43,27 +43,30 @@ jobs:
           [[ ${status} -eq 0 ]] && echo "Generated files are up-to-date"
           exit ${status}
 
-      - name: Validate task YAMLs
+      - name: Validate task and stepaction YAMLs
         run: |
-          for f in task/*/golang-*.yaml; do
+          validate() {
+            local f="$1" want_kind="$2" want_api="$3"
             echo -n "--- Validating ${f} ... "
-            # Check YAML is valid and has expected Tekton structure
             apiVersion=$(yq '.apiVersion' "${f}")
             kind=$(yq '.kind' "${f}")
             name=$(yq '.metadata.name' "${f}")
-            if [[ "${apiVersion}" != "tekton.dev/v1" ]]; then
-              echo "FAIL: expected apiVersion tekton.dev/v1, got ${apiVersion}"
-              exit 1
+            if [[ "${apiVersion}" != "${want_api}" ]]; then
+              echo "FAIL: expected apiVersion ${want_api}, got ${apiVersion}"; exit 1
             fi
-            if [[ "${kind}" != "Task" ]]; then
-              echo "FAIL: expected kind Task, got ${kind}"
-              exit 1
+            if [[ "${kind}" != "${want_kind}" ]]; then
+              echo "FAIL: expected kind ${want_kind}, got ${kind}"; exit 1
             fi
             if [[ -z "${name}" || "${name}" == "null" ]]; then
-              echo "FAIL: metadata.name is missing"
-              exit 1
+              echo "FAIL: metadata.name is missing"; exit 1
             fi
             echo "OK (${kind}/${name})"
+          }
+          for f in task/*/golang-*.yaml; do
+            validate "${f}" Task tekton.dev/v1
+          done
+          for f in stepaction/*/*.yaml; do
+            validate "${f}" StepAction tekton.dev/v1beta1
           done
 
   e2e:
@@ -114,6 +117,25 @@ jobs:
           TIMEOUT: 300s
         run: ./test/e2e-tests-alpine.sh
 
+  e2e-stepactions:
+    name: E2E StepActions (latest LTS)
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: kind
+          wait: 120s
+
+      - name: Run StepAction e2e tests
+        env:
+          PIPELINE_VERSION: v1.12.0
+          TIMEOUT: 300s
+        run: ./test/e2e-stepactions.sh
+
   e2e-bundle:
     name: E2E Bundle
     needs: [lint]
@@ -137,7 +159,7 @@ jobs:
 
   ci-summary:
     name: CI summary
-    needs: [lint, e2e, e2e-alpine, e2e-bundle]
+    needs: [lint, e2e, e2e-alpine, e2e-stepactions, e2e-bundle]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -147,6 +169,7 @@ jobs:
             "lint=${NEEDS_LINT_RESULT}"
             "e2e=${NEEDS_E2E_RESULT}"
             "e2e-alpine=${NEEDS_E2E_ALPINE_RESULT}"
+            "e2e-stepactions=${NEEDS_E2E_STEPACTIONS_RESULT}"
             "e2e-bundle=${NEEDS_E2E_BUNDLE_RESULT}"
           )
           failed=0
@@ -169,4 +192,5 @@ jobs:
           NEEDS_LINT_RESULT: ${{ needs.lint.result }}
           NEEDS_E2E_RESULT: ${{ needs.e2e.result }}
           NEEDS_E2E_ALPINE_RESULT: ${{ needs.e2e-alpine.result }}
+          NEEDS_E2E_STEPACTIONS_RESULT: ${{ needs.e2e-stepactions.result }}
           NEEDS_E2E_BUNDLE_RESULT: ${{ needs.e2e-bundle.result }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,8 @@ jobs:
               status=1
               continue
             fi
-            a=$(git show "HEAD:${f}" | yq 'del(.metadata.annotations."tekton.dev/signature") | sort_keys(..)')
-            b=$(yq 'del(.metadata.annotations."tekton.dev/signature") | sort_keys(..)' "${f}")
+            a=$(git show "HEAD:${f}" | yq 'del(.metadata.annotations."tekton.dev/signature", .metadata.annotations."artifacthub.io/changes") | sort_keys(..)')
+            b=$(yq 'del(.metadata.annotations."tekton.dev/signature", .metadata.annotations."artifacthub.io/changes") | sort_keys(..)' "${f}")
             if [[ "${a}" != "${b}" ]]; then
               echo "ERROR: ${f} is out of date. Run ./hack/generate.sh and commit."
               diff <(echo "${a}") <(echo "${b}") || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,15 @@ jobs:
             tkn bundle push "${REGISTRY}/${task}:latest" \
               -f "${taskdir}/${task}.yaml"
           done
+          for sadir in stepaction/*/; do
+            sa=$(basename "${sadir}")
+            [[ -f "${sadir}${sa}.yaml" ]] || continue
+            echo "--- Publishing bundle for stepaction-${sa}"
+            tkn bundle push "${REGISTRY}/stepaction-${sa}:${GIT_TAG}" \
+              -f "${sadir}${sa}.yaml"
+            tkn bundle push "${REGISTRY}/stepaction-${sa}:latest" \
+              -f "${sadir}${sa}.yaml"
+          done
 
       - name: Sign Tekton Bundles
         env:
@@ -58,6 +67,16 @@ jobs:
                 -a GIT_TAG="${GIT_TAG}" \
                 "${REGISTRY}/${task}@${digest}"
           done
+          for sadir in stepaction/*/; do
+            sa=$(basename "${sadir}")
+            [[ -f "${sadir}${sa}.yaml" ]] || continue
+            echo "--- Signing bundle for stepaction-${sa}"
+            digest=$(crane digest "${REGISTRY}/stepaction-${sa}:${GIT_TAG}")
+            cosign sign --yes \
+                -a GIT_HASH="${{ github.sha }}" \
+                -a GIT_TAG="${GIT_TAG}" \
+                "${REGISTRY}/stepaction-${sa}@${digest}"
+          done
 
       - name: Create GitHub Release
         env:
@@ -72,6 +91,11 @@ jobs:
             task=$(basename "${taskdir}")
             INSTALL_LINES+="          kubectl apply -f https://raw.githubusercontent.com/${{ github.repository }}/${GIT_TAG}/${taskdir}/${task}.yaml\n"
             BUNDLE_LINES+="          - \`${REGISTRY}/${task}:${GIT_TAG}\`\n"
+          done
+          for sadir in stepaction/*/; do
+            sa=$(basename "${sadir}")
+            [[ -f "${sadir}${sa}.yaml" ]] || continue
+            BUNDLE_LINES+="          - \`${REGISTRY}/stepaction-${sa}:${GIT_TAG}\`\n"
           done
 
           cat <<EOF > release-notes.md

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/golang)](https://artifacthub.io/packages/search?repo=golang)
 
-This repository contains verified Tekton Tasks for building and testing Go projects.
+This repository contains verified Tekton Tasks and StepActions for building and testing Go projects.
 
 ## Tasks
 
@@ -12,6 +12,53 @@ This repository contains verified Tekton Tasks for building and testing Go proje
 | [`golang-build-alpine`](task/golang-build-alpine/) | Build Go packages (Alpine) | 1.26 |
 | [`golang-test`](task/golang-test/) | Run Go tests | 1.26 |
 | [`golang-test-alpine`](task/golang-test-alpine/) | Run Go tests (Alpine) | 1.26 |
+
+## StepActions
+
+[StepActions](https://tekton.dev/docs/pipelines/stepactions/) are composable
+steps you can combine into a single Task — e.g. `git-clone` + `golang-fmt` +
+`golang-vet` + `golang-build` + `golang-test`. Each StepAction is also
+available in Debian (default) and Alpine variants.
+
+| StepAction | Description | Task equivalent |
+|------------|-------------|-----------------|
+| [`golang-build`](stepaction/golang-build/) | Build Go packages | ✅ |
+| [`golang-test`](stepaction/golang-test/) | Run Go tests | ✅ |
+| [`golang-fmt`](stepaction/golang-fmt/) | Check formatting (`gofmt -l`) | StepAction-only |
+| [`golang-vet`](stepaction/golang-vet/) | Static analysis (`go vet`) | StepAction-only |
+| [`golang-fix`](stepaction/golang-fix/) | Modernize code (`go fix`, Go 1.26+) | StepAction-only |
+| [`govulncheck`](stepaction/govulncheck/) | Vulnerability scanning | StepAction-only |
+
+StepActions require Tekton Pipelines with `enable-step-actions: "true"`. The
+source code is passed via the `source-path` param (instead of a workspace).
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: go-ci
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: fmt
+        ref: { name: golang-fmt }
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+      - name: build
+        ref: { name: golang-build }
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+          - name: package
+            value: github.com/my-org/my-project
+```
 
 
 ## Variants

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ available in Debian (default) and Alpine variants.
 | [`golang-build`](stepaction/golang-build/) | Build Go packages | ✅ |
 | [`golang-test`](stepaction/golang-test/) | Run Go tests | ✅ |
 | [`golang-fmt`](stepaction/golang-fmt/) | Check formatting (`gofmt -l`) | StepAction-only |
+| [`golang-goimports`](stepaction/golang-goimports/) | Check formatting + imports (`goimports -l`) | StepAction-only |
 | [`golang-vet`](stepaction/golang-vet/) | Static analysis (`go vet`) | StepAction-only |
 | [`golang-fix`](stepaction/golang-fix/) | Modernize code (`go fix`, Go 1.26+) | StepAction-only |
 | [`govulncheck`](stepaction/govulncheck/) | Vulnerability scanning | StepAction-only |

--- a/base/golang-build.yaml
+++ b/base/golang-build.yaml
@@ -35,7 +35,7 @@ spec:
       description: golang version to use for builds
       default: "1.26"
     - name: flags
-      description: flags to use for the test command
+      description: flags to use for the build command
       default: -v
     - name: GOOS
       description: running program's operating system target

--- a/base/golang-build.yaml
+++ b/base/golang-build.yaml
@@ -79,11 +79,17 @@ spec:
           value: $(params.CGO_ENABLED)
         - name: GOSUMDB
           value: $(params.GOSUMDB)
+        - name: PACKAGE
+          value: $(params.package)
+        - name: PACKAGES
+          value: $(params.packages)
+        - name: FLAGS
+          value: $(params.flags)
       script: |
-        if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-          SRC_PATH="$GOPATH/src/$(params.package)"
+        if [ ! -e $GOPATH/src/${PACKAGE}/go.mod ];then
+          SRC_PATH="$GOPATH/src/${PACKAGE}"
           mkdir -p $SRC_PATH
           cp -R "$(workspaces.source.path)"/* $SRC_PATH
           cd $SRC_PATH
         fi
-        go build $(params.flags) $(params.packages)
+        go build ${FLAGS} ${PACKAGES}

--- a/base/golang-fix.yaml
+++ b/base/golang-fix.yaml
@@ -37,5 +37,8 @@ spec:
       default: "1.26"
   image: IMAGE_PLACEHOLDER
   workingDir: $(params.source-path)
+  env:
+    - name: PARAM_PACKAGES
+      value: $(params.packages)
   script: |
-    go fix $(params.packages)
+    go fix ${PARAM_PACKAGES}

--- a/base/golang-fix.yaml
+++ b/base/golang-fix.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang fix
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: modernize
 spec:

--- a/base/golang-fix.yaml
+++ b/base/golang-fix.yaml
@@ -1,0 +1,41 @@
+# Base template for golang-fix StepAction. Do not edit generated files directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-fix
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Code Quality
+    tekton.dev/displayName: golang fix
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: modernize
+spec:
+  description: This StepAction runs 'go fix' to modernize Go source code to use newer language and library features (Go 1.26+).
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: packages
+      description: packages to fix
+      default: ./...
+    - name: version
+      description: golang version to use (1.26+ required for the modernizing 'go fix')
+      default: "1.26"
+  image: IMAGE_PLACEHOLDER
+  workingDir: $(params.source-path)
+  script: |
+    go fix $(params.packages)

--- a/base/golang-fmt.yaml
+++ b/base/golang-fmt.yaml
@@ -1,0 +1,49 @@
+# Base template for golang-fmt StepAction. Do not edit generated files directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-fmt
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Code Quality
+    tekton.dev/displayName: golang fmt
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: lint
+spec:
+  description: This StepAction checks that Go source code is formatted with gofmt and fails if any file needs formatting.
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: paths
+      description: paths to check for formatting
+      default: .
+    - name: version
+      description: golang version to use
+      default: "1.26"
+  image: IMAGE_PLACEHOLDER
+  workingDir: $(params.source-path)
+  script: |
+    unformatted=$(gofmt -l $(params.paths))
+    if [ -n "${unformatted}" ]; then
+      echo "The following files are not formatted:"
+      echo "${unformatted}"
+      echo ""
+      echo "Run 'gofmt -w' on them to fix."
+      exit 1
+    fi
+    echo "All Go files are correctly formatted."

--- a/base/golang-fmt.yaml
+++ b/base/golang-fmt.yaml
@@ -32,6 +32,9 @@ spec:
     - name: paths
       description: paths to check for formatting
       default: .
+    - name: skip-dirs
+      description: directories to exclude (pipe-separated regex, e.g. 'vendor|third_party')
+      default: vendor
     - name: version
       description: golang version to use
       default: "1.26"
@@ -40,8 +43,14 @@ spec:
   env:
     - name: PARAM_PATHS
       value: $(params.paths)
+    - name: SKIP_DIRS
+      value: $(params.skip-dirs)
   script: |
-    unformatted=$(gofmt -l ${PARAM_PATHS})
+    if [ -n "${SKIP_DIRS}" ]; then
+      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs gofmt -l 2>/dev/null)
+    else
+      unformatted=$(gofmt -l ${PARAM_PATHS})
+    fi
     if [ -n "${unformatted}" ]; then
       echo "The following files are not formatted:"
       echo "${unformatted}"

--- a/base/golang-fmt.yaml
+++ b/base/golang-fmt.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang fmt
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
 spec:
@@ -47,7 +47,7 @@ spec:
       value: $(params.skip-dirs)
   script: |
     if [ -n "${SKIP_DIRS}" ]; then
-      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs gofmt -l 2>/dev/null)
+      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "(^|/)${SKIP_DIRS}/" | xargs gofmt -l 2>/dev/null)
     else
       unformatted=$(gofmt -l ${PARAM_PATHS})
     fi

--- a/base/golang-fmt.yaml
+++ b/base/golang-fmt.yaml
@@ -37,8 +37,11 @@ spec:
       default: "1.26"
   image: IMAGE_PLACEHOLDER
   workingDir: $(params.source-path)
+  env:
+    - name: PARAM_PATHS
+      value: $(params.paths)
   script: |
-    unformatted=$(gofmt -l $(params.paths))
+    unformatted=$(gofmt -l ${PARAM_PATHS})
     if [ -n "${unformatted}" ]; then
       echo "The following files are not formatted:"
       echo "${unformatted}"

--- a/base/golang-goimports.yaml
+++ b/base/golang-goimports.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang goimports
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
 spec:
@@ -56,7 +56,7 @@ spec:
     export PATH="${GOBIN}:${PATH}"
     go install golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}
     if [ -n "${SKIP_DIRS}" ]; then
-      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs goimports -l 2>/dev/null)
+      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "(^|/)${SKIP_DIRS}/" | xargs goimports -l 2>/dev/null)
     else
       unformatted=$(goimports -l ${PARAM_PATHS})
     fi

--- a/base/golang-goimports.yaml
+++ b/base/golang-goimports.yaml
@@ -1,8 +1,8 @@
-# Generated from base/golang-fmt.yaml — do not edit directly.
+# Base template for golang-goimports StepAction. Do not edit generated files directly.
 apiVersion: tekton.dev/v1beta1
 kind: StepAction
 metadata:
-  name: golang-fmt-alpine
+  name: golang-goimports
   annotations:
     artifacthub.io/category: integration-delivery
     artifacthub.io/license: Apache-2.0
@@ -19,14 +19,12 @@ metadata:
     tekton.dev/catalog-support-tier: verified
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
-    tekton.dev/displayName: golang fmt (alpine)
+    tekton.dev/displayName: golang goimports
     tekton.dev/pipelines.minVersion: 0.40.0
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
-  labels:
-    app.kubernetes.io/version: 1.2.0
 spec:
-  description: This StepAction checks that Go source code is formatted with gofmt and fails if any file needs formatting. Uses the Alpine-based Go image for smaller footprint.
+  description: This StepAction checks that Go source code is formatted and imports are organized using goimports. It is a superset of gofmt — it also groups and sorts import statements.
   params:
     - name: source-path
       description: Path to the Go source code to operate on.
@@ -37,27 +35,36 @@ spec:
     - name: skip-dirs
       description: directories to exclude (pipe-separated regex, e.g. 'vendor|third_party')
       default: vendor
+    - name: goimports-version
+      description: version of goimports to install
+      default: latest
     - name: version
       description: golang version to use
       default: "1.26"
-  image: docker.io/library/golang:$(params.version)-alpine
+  image: IMAGE_PLACEHOLDER
   workingDir: $(params.source-path)
   env:
+    - name: GOBIN
+      value: /tekton/home/go/bin
     - name: PARAM_PATHS
       value: $(params.paths)
     - name: SKIP_DIRS
       value: $(params.skip-dirs)
+    - name: GOIMPORTS_VERSION
+      value: $(params.goimports-version)
   script: |
+    export PATH="${GOBIN}:${PATH}"
+    go install golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}
     if [ -n "${SKIP_DIRS}" ]; then
-      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs gofmt -l 2>/dev/null)
+      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs goimports -l 2>/dev/null)
     else
-      unformatted=$(gofmt -l ${PARAM_PATHS})
+      unformatted=$(goimports -l ${PARAM_PATHS})
     fi
     if [ -n "${unformatted}" ]; then
-      echo "The following files are not formatted:"
+      echo "The following files have incorrect formatting or imports:"
       echo "${unformatted}"
       echo ""
-      echo "Run 'gofmt -w' on them to fix."
+      echo "Run 'goimports -w' on them to fix."
       exit 1
     fi
-    echo "All Go files are correctly formatted."
+    echo "All Go files have correct formatting and imports."

--- a/base/golang-test.yaml
+++ b/base/golang-test.yaml
@@ -72,11 +72,19 @@ spec:
           value: $(params.GOCACHE)
         - name: GOMODCACHE
           value: $(params.GOMODCACHE)
+        - name: PACKAGE
+          value: $(params.package)
+        - name: PACKAGES
+          value: $(params.packages)
+        - name: FLAGS
+          value: $(params.flags)
+        - name: CONTEXT
+          value: $(params.context)
       script: |
-        if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-           SRC_PATH="$GOPATH/src/$(params.package)"
+        if [ ! -e $GOPATH/src/${PACKAGE}/go.mod ];then
+           SRC_PATH="$GOPATH/src/${PACKAGE}"
            mkdir -p $SRC_PATH
-           cp -R "$(workspaces.source.path)/$(params.context)"/* $SRC_PATH
+           cp -R "$(workspaces.source.path)/${CONTEXT}"/* $SRC_PATH
            cd $SRC_PATH
         fi
-        go test $(params.flags) $(params.packages)
+        go test ${FLAGS} ${PACKAGES}

--- a/base/golang-vet.yaml
+++ b/base/golang-vet.yaml
@@ -40,5 +40,10 @@ spec:
       default: "1.26"
   image: IMAGE_PLACEHOLDER
   workingDir: $(params.source-path)
+  env:
+    - name: PARAM_FLAGS
+      value: $(params.flags)
+    - name: PARAM_PACKAGES
+      value: $(params.packages)
   script: |
-    go vet $(params.flags) $(params.packages)
+    go vet ${PARAM_FLAGS} ${PARAM_PACKAGES}

--- a/base/golang-vet.yaml
+++ b/base/golang-vet.yaml
@@ -1,0 +1,44 @@
+# Base template for golang-vet StepAction. Do not edit generated files directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-vet
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Code Quality
+    tekton.dev/displayName: golang vet
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: lint
+spec:
+  description: This StepAction runs 'go vet' to report likely mistakes in Go source code.
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: packages
+      description: packages to vet
+      default: ./...
+    - name: flags
+      description: additional flags to pass to 'go vet'
+      default: ""
+    - name: version
+      description: golang version to use
+      default: "1.26"
+  image: IMAGE_PLACEHOLDER
+  workingDir: $(params.source-path)
+  script: |
+    go vet $(params.flags) $(params.packages)

--- a/base/golang-vet.yaml
+++ b/base/golang-vet.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang vet
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
 spec:

--- a/base/govulncheck.yaml
+++ b/base/govulncheck.yaml
@@ -43,7 +43,11 @@ spec:
   env:
     - name: GOBIN
       value: /tekton/home/go/bin
+    - name: PARAM_GOVULNCHECK_VERSION
+      value: $(params.govulncheck-version)
+    - name: PARAM_PACKAGES
+      value: $(params.packages)
   script: |
     export PATH="${GOBIN}:${PATH}"
-    go install golang.org/x/vuln/cmd/govulncheck@$(params.govulncheck-version)
-    govulncheck $(params.packages)
+    go install golang.org/x/vuln/cmd/govulncheck@${PARAM_GOVULNCHECK_VERSION}
+    govulncheck ${PARAM_PACKAGES}

--- a/base/govulncheck.yaml
+++ b/base/govulncheck.yaml
@@ -1,0 +1,49 @@
+# Base template for govulncheck StepAction. Do not edit generated files directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: govulncheck
+  annotations:
+    artifacthub.io/category: security
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Security
+    tekton.dev/displayName: govulncheck
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: security
+spec:
+  description: This StepAction scans Go code for known vulnerabilities using govulncheck.
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: packages
+      description: packages to scan
+      default: ./...
+    - name: govulncheck-version
+      description: version of govulncheck to install
+      default: latest
+    - name: version
+      description: golang version to use
+      default: "1.26"
+  image: IMAGE_PLACEHOLDER
+  workingDir: $(params.source-path)
+  env:
+    - name: GOBIN
+      value: /tekton/home/go/bin
+  script: |
+    export PATH="${GOBIN}:${PATH}"
+    go install golang.org/x/vuln/cmd/govulncheck@$(params.govulncheck-version)
+    govulncheck $(params.packages)

--- a/base/govulncheck.yaml
+++ b/base/govulncheck.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Security
     tekton.dev/displayName: govulncheck
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: security
 spec:

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -1,0 +1,33 @@
+# Catalog manifest — single source of truth for what the generator produces.
+#
+# Each tool lists the kinds to generate:
+#   - task:       a Tekton Task (from a kind: Task base template)
+#   - stepaction: a Tekton StepAction
+#                 * derived from the generated Task when the base is a Task
+#                 * generated directly when the base is a kind: StepAction template
+#
+# Every tool is produced for every variant below (Debian + Alpine).
+#
+# Downstream consumers can fork this file and point the generator at it:
+#   ./hack/generate.sh my-catalog.yaml
+tools:
+  - name: golang-build
+    generate: [task, stepaction]
+  - name: golang-test
+    generate: [task, stepaction]
+  - name: golang-fmt
+    generate: [stepaction]
+  - name: golang-vet
+    generate: [stepaction]
+  - name: golang-fix
+    generate: [stepaction]
+  - name: govulncheck
+    generate: [stepaction]
+
+variants:
+  - suffix: ""
+    image: "docker.io/library/golang:$(params.version)"
+    description_suffix: ""
+  - suffix: "-alpine"
+    image: "docker.io/library/golang:$(params.version)-alpine"
+    description_suffix: " Uses the Alpine-based Go image for smaller footprint."

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -17,6 +17,8 @@ tools:
     generate: [task, stepaction]
   - name: golang-fmt
     generate: [stepaction]
+  - name: golang-goimports
+    generate: [stepaction]
   - name: golang-vet
     generate: [stepaction]
   - name: golang-fix

--- a/hack/generate-stepaction.py
+++ b/hack/generate-stepaction.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Derive a StepAction YAML from a generated golang Task YAML.
+
+The golang tasks are single-step and use a single `source` workspace, so the
+derivation is simpler than git-clone's: the `source` workspace becomes a
+`source-path` param, and references to `$(workspaces.source.path)` are
+rewritten to `$(params.source-path)`. The golang tasks produce no results.
+
+Usage: generate-stepaction.py <task.yaml> <stepaction.yaml>
+
+Requires PyYAML. Invoke via: uv run --with pyyaml python3 hack/generate-stepaction.py ...
+"""
+
+import copy
+import re
+import sys
+
+import yaml
+
+# Workspace → param mapping for golang tasks.
+SOURCE_PARAM = {
+    "name": "source-path",
+    "description": "Path to the Go source code to operate on.",
+    "type": "string",
+}
+
+WORKSPACE_PATH_REF = "$(workspaces.source.path)"
+PARAM_PATH_REF = "$(params.source-path)"
+
+
+class StepActionDumper(yaml.SafeDumper):
+    pass
+
+
+def str_representer(dumper, data):
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    if data == "" or re.match(r"^[\d.]+$", data):
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='"')
+    if data.lower() in ("true", "false", "yes", "no"):
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='"')
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+StepActionDumper.add_representer(str, str_representer)
+
+
+def transform_description(desc: str) -> str:
+    d = desc
+    d = d.replace("This Task is Golang task to", "This StepAction is a Golang step to")
+    d = d.replace("this Task", "this StepAction")
+    d = d.replace("This Task", "This StepAction")
+    return d
+
+
+def rewrite_workspace_refs(text: str) -> str:
+    return text.replace(WORKSPACE_PATH_REF, PARAM_PATH_REF)
+
+
+def generate(task_file: str, output_file: str) -> None:
+    with open(task_file) as f:
+        task = yaml.safe_load(f)
+
+    meta = task["metadata"]
+    spec = task["spec"]
+    step = spec["steps"][0]
+
+    sa = {
+        "apiVersion": "tekton.dev/v1beta1",
+        "kind": "StepAction",
+        "metadata": {
+            "name": meta["name"],
+            "labels": {
+                "app.kubernetes.io/version": meta.get("labels", {}).get(
+                    "app.kubernetes.io/version", "0.1"
+                ),
+            },
+            "annotations": {},
+        },
+        "spec": {},
+    }
+
+    # Copy annotations (skip any signature).
+    for k, v in meta.get("annotations", {}).items():
+        if k == "tekton.dev/signature":
+            continue
+        sa["metadata"]["annotations"][k] = v
+
+    sa["spec"]["description"] = transform_description(spec.get("description", ""))
+
+    # Params: source-path replaces the workspace, then the task's own params.
+    sa["spec"]["params"] = [copy.deepcopy(SOURCE_PARAM)]
+    for p in spec.get("params", []):
+        p2 = copy.deepcopy(p)
+        if "description" in p2 and isinstance(p2["description"], str):
+            p2["description"] = p2["description"].replace("this Task", "this StepAction")
+        sa["spec"]["params"].append(p2)
+
+    sa["spec"]["image"] = step["image"]
+
+    if "workingDir" in step:
+        sa["spec"]["workingDir"] = rewrite_workspace_refs(step["workingDir"])
+
+    if "env" in step:
+        sa["spec"]["env"] = copy.deepcopy(step["env"])
+
+    if "securityContext" in step:
+        sa["spec"]["securityContext"] = copy.deepcopy(step["securityContext"])
+
+    sa["spec"]["script"] = rewrite_workspace_refs(step.get("script", ""))
+
+    header = (
+        f"# Generated from task/{meta['name']}/{meta['name']}.yaml \u2014 do not edit directly.\n"
+    )
+
+    with open(output_file, "w") as f:
+        f.write(header)
+        yaml.dump(
+            sa,
+            f,
+            Dumper=StepActionDumper,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <task.yaml> <stepaction.yaml>", file=sys.stderr)
+        sys.exit(1)
+    generate(sys.argv[1], sys.argv[2])

--- a/hack/generate-stepaction.py
+++ b/hack/generate-stepaction.py
@@ -40,7 +40,15 @@ SOURCE_PARAM = {
 }
 
 WORKSPACE_PATH_REF = "$(workspaces.source.path)"
-PARAM_PATH_REF = "$(params.source-path)"
+# In StepAction scripts, $(params.*) is not allowed — use an env var instead.
+# The workingDir and env value fields still support $(params.*) substitution.
+ENV_SOURCE_PATH_REF = "${SOURCE_PATH}"
+PARAM_SOURCE_PATH_REF = "$(params.source-path)"
+
+SOURCE_PATH_ENV = {
+    "name": "SOURCE_PATH",
+    "value": "$(params.source-path)",
+}
 
 
 class StepActionDumper(yaml.SafeDumper):
@@ -68,8 +76,14 @@ def transform_description(desc: str) -> str:
     return d
 
 
-def rewrite_workspace_refs(text: str) -> str:
-    return text.replace(WORKSPACE_PATH_REF, PARAM_PATH_REF)
+def rewrite_workspace_refs_script(text: str) -> str:
+    """Rewrite workspace refs in scripts to env var (no $(params.*) in scripts)."""
+    return text.replace(WORKSPACE_PATH_REF, ENV_SOURCE_PATH_REF)
+
+
+def rewrite_workspace_refs_field(text: str) -> str:
+    """Rewrite workspace refs in non-script fields (workingDir etc.)."""
+    return text.replace(WORKSPACE_PATH_REF, PARAM_SOURCE_PATH_REF)
 
 
 def generate(task_file: str, output_file: str) -> None:
@@ -114,15 +128,19 @@ def generate(task_file: str, output_file: str) -> None:
     sa["spec"]["image"] = step["image"]
 
     if "workingDir" in step:
-        sa["spec"]["workingDir"] = rewrite_workspace_refs(step["workingDir"])
+        sa["spec"]["workingDir"] = rewrite_workspace_refs_field(step["workingDir"])
 
     if "env" in step:
         sa["spec"]["env"] = copy.deepcopy(step["env"])
+    else:
+        sa["spec"]["env"] = []
+    # Add SOURCE_PATH env var for script references.
+    sa["spec"]["env"].append(copy.deepcopy(SOURCE_PATH_ENV))
 
     if "securityContext" in step:
         sa["spec"]["securityContext"] = copy.deepcopy(step["securityContext"])
 
-    sa["spec"]["script"] = rewrite_workspace_refs(step.get("script", ""))
+    sa["spec"]["script"] = rewrite_workspace_refs_script(step.get("script", ""))
 
     header = (
         f"# Generated from task/{meta['name']}/{meta['name']}.yaml \u2014 do not edit directly.\n"

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -113,7 +113,7 @@ for t in $(seq 0 $((TOOL_COUNT - 1))); do
   for i in $(seq 0 $((VARIANT_COUNT - 1))); do
     suffix="$(yq ".variants[${i}].suffix" "${MANIFEST}")"
     image="$(yq ".variants[${i}].image" "${MANIFEST}")"
-    description_suffix="$(yq ".variants[${i}].description_suffix" "${MANIFEST}")"
+    description_suffix="$(yq ".variants[${i}].description_suffix // \"\"" "${MANIFEST}")"
 
     obj_name="${name}${suffix}"
 

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -1,18 +1,28 @@
 #!/usr/bin/env bash
-# Generates task YAML files from base/ templates and variant definitions.
-# Usage: ./hack/generate.sh [variants-file]
-#   variants-file: path to variants YAML (default: variants.yaml in repo root)
+# Generates Task and StepAction YAML files from base/ templates, the catalog
+# manifest, and the VERSION file.
+#
+# Usage: ./hack/generate.sh [catalog-file]
+#   catalog-file: path to the catalog manifest (default: catalog.yaml in root)
+#
+# The catalog manifest lists each tool and the kinds to generate:
+#   tools:
+#     - name: golang-build
+#       generate: [task, stepaction]   # Task base → Task + derived StepAction
+#     - name: golang-fmt
+#       generate: [stepaction]         # StepAction base → StepAction only
+#   variants: [...]                    # applied to every generated artifact
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-VARIANTS_FILE="${1:-${REPO_ROOT}/variants.yaml}"
+MANIFEST="${1:-${REPO_ROOT}/catalog.yaml}"
 
 # Version is the single source of truth in the VERSION file at the repo root.
-# It is injected into generated task files as the app.kubernetes.io/version
-# label, so base/ templates stay version-agnostic and generation stays
-# deterministic (CI can reproduce the exact committed files).
+# It is injected into generated files as the app.kubernetes.io/version label,
+# so base/ templates stay version-agnostic and generation stays deterministic
+# (CI can reproduce the exact committed files).
 VERSION_FILE="${REPO_ROOT}/VERSION"
 if [[ ! -f "${VERSION_FILE}" ]]; then
   echo "Error: VERSION file not found: ${VERSION_FILE}" >&2
@@ -20,8 +30,8 @@ if [[ ! -f "${VERSION_FILE}" ]]; then
 fi
 VERSION="$(tr -d '[:space:]' < "${VERSION_FILE}")"
 
-if [[ ! -f "${VARIANTS_FILE}" ]]; then
-  echo "Error: variants file not found: ${VARIANTS_FILE}" >&2
+if [[ ! -f "${MANIFEST}" ]]; then
+  echo "Error: catalog manifest not found: ${MANIFEST}" >&2
   exit 1
 fi
 
@@ -32,71 +42,133 @@ fi
 
 BASE_DIR="${REPO_ROOT}/base"
 TASK_DIR="${REPO_ROOT}/task"
+STEPACTION_DIR="${REPO_ROOT}/stepaction"
 
-VARIANT_COUNT="$(yq '.variants | length' "${VARIANTS_FILE}")"
+# Python runner for the StepAction derivation script. Prefer uv (pulls in
+# PyYAML without polluting the system), fall back to a python3 that already
+# has yaml available.
+if command -v uv &>/dev/null; then
+  PYRUN=(uv run --quiet --with pyyaml python3)
+elif python3 -c 'import yaml' 2>/dev/null; then
+  PYRUN=(python3)
+else
+  echo "Error: need either 'uv' or a python3 with PyYAML for StepAction derivation" >&2
+  exit 1
+fi
 
-for base_file in "${BASE_DIR}"/*.yaml; do
+VARIANT_COUNT="$(yq '.variants | length' "${MANIFEST}")"
+TOOL_COUNT="$(yq '.tools | length' "${MANIFEST}")"
+
+# render_with_variant <base_file> <kind_path> <name> <image> <desc_suffix> <display_suffix>
+# Emits a generated YAML (with header) to stdout: substitutes the image at the
+# given path, sets the name, injects the version label, and appends the
+# description/displayName suffixes.
+render_with_variant() {
+  local base_file="$1" image_path="$2" name="$3" image="$4" desc_suffix="$5" display_suffix="$6"
+  local base_filename
   base_filename="$(basename "${base_file}")"
-  base_name="${base_filename%.yaml}"
+  printf '# Generated from base/%s \xe2\x80\x94 do not edit directly.\n' "${base_filename}"
+  tail -n +2 "${base_file}" | yq eval \
+    "${image_path} = \"${image}\" |
+     .metadata.name = \"${name}\" |
+     .metadata.labels[\"app.kubernetes.io/version\"] = \"${VERSION}\" |
+     .spec.description = (.spec.description + \"${desc_suffix}\") |
+     .metadata.annotations[\"tekton.dev/displayName\"] = (.metadata.annotations[\"tekton.dev/displayName\"] + \"${display_suffix}\")" \
+    -
+}
 
-  echo "Processing base: ${base_name}"
+# variant_readme <default_dir> <variant_dir> <base_name> <obj_name> <path_prefix>
+# Generates a variant README from the default tool's README, rewriting names
+# and paths. No-op if the default README does not exist.
+variant_readme() {
+  local default_dir="$1" variant_dir="$2" base_name="$3" obj_name="$4" path_prefix="$5"
+  if [[ -f "${default_dir}/README.md" ]]; then
+    sed -e "s|${path_prefix}/${base_name}/${base_name}|${path_prefix}/${obj_name}/${obj_name}|g" \
+        -e "s|name: ${base_name}|name: ${obj_name}|g" \
+        "${default_dir}/README.md" > "${variant_dir}/README.md"
+    echo "    Generated README.md from ${default_dir}/"
+  fi
+}
+
+for t in $(seq 0 $((TOOL_COUNT - 1))); do
+  name="$(yq ".tools[${t}].name" "${MANIFEST}")"
+  mapfile -t modes < <(yq ".tools[${t}].generate[]" "${MANIFEST}")
+  base_file="${BASE_DIR}/${name}.yaml"
+
+  if [[ ! -f "${base_file}" ]]; then
+    echo "Error: base template not found: ${base_file}" >&2
+    exit 1
+  fi
+
+  base_kind="$(yq '.kind' "${base_file}")"
+  echo "Processing tool: ${name} (kind=${base_kind}, generate=${modes[*]})"
+
+  want_task=false
+  want_stepaction=false
+  for m in "${modes[@]}"; do
+    [[ "${m}" == "task" ]] && want_task=true
+    [[ "${m}" == "stepaction" ]] && want_stepaction=true
+  done
 
   for i in $(seq 0 $((VARIANT_COUNT - 1))); do
-    suffix="$(yq ".variants[${i}].suffix" "${VARIANTS_FILE}")"
-    image="$(yq ".variants[${i}].image" "${VARIANTS_FILE}")"
-    description_suffix="$(yq ".variants[${i}].description_suffix" "${VARIANTS_FILE}")"
+    suffix="$(yq ".variants[${i}].suffix" "${MANIFEST}")"
+    image="$(yq ".variants[${i}].image" "${MANIFEST}")"
+    description_suffix="$(yq ".variants[${i}].description_suffix" "${MANIFEST}")"
 
-    task_name="${base_name}${suffix}"
-    task_dir="${TASK_DIR}/${task_name}"
-    task_file="${task_dir}/${task_name}.yaml"
+    obj_name="${name}${suffix}"
 
-    echo "  → ${task_name}"
-
-    # Create task dir if it doesn't exist
-    mkdir -p "${task_dir}"
-
-    # For non-default variants, seed OWNERS and generate README from the default
-    # task dir, replacing task names and paths for the variant.
+    # Display-name suffix: "-alpine" → " (alpine)", "" → ""
     if [[ -n "${suffix}" ]]; then
-      default_dir="${TASK_DIR}/${base_name}"
-      # Generate README with variant-specific names and paths
-      if [[ -f "${default_dir}/README.md" ]]; then
-        sed -e "s|task/${base_name}/${base_name}|task/${task_name}/${task_name}|g" \
-            -e "s|name: ${base_name}|name: ${task_name}|g" \
-            "${default_dir}/README.md" > "${task_dir}/README.md"
-        echo "    Generated README.md from ${default_dir}/"
-      fi
-    fi
-
-    # Build display-name suffix: "-alpine" → " (alpine)", "" → ""
-    if [[ -n "${suffix}" ]]; then
-      variant_label="${suffix#-}"
-      display_suffix=" (${variant_label})"
+      display_suffix=" (${suffix#-})"
     else
       display_suffix=""
     fi
 
-    # Generate the task YAML:
-    #  1. Strip the base template's header comment (first line).
-    #  2. Pipe through yq to:
-    #       - Replace IMAGE_PLACEHOLDER with the variant image.
-    #       - Set metadata.name to the task name.
-    #       - Append description_suffix to spec.description.
-    #       - Append display_suffix to tekton.dev/displayName annotation.
-    #  3. Prepend a "do not edit" header comment.
-    {
-      printf '# Generated from base/%s \xe2\x80\x94 do not edit directly.\n' "${base_filename}"
-      tail -n +2 "${base_file}" | yq eval \
-        ".spec.steps[].image = \"${image}\" |
-         .metadata.name = \"${task_name}\" |
-         .metadata.labels[\"app.kubernetes.io/version\"] = \"${VERSION}\" |
-         .spec.description = (.spec.description + \"${description_suffix}\") |
-         .metadata.annotations[\"tekton.dev/displayName\"] = (.metadata.annotations[\"tekton.dev/displayName\"] + \"${display_suffix}\")" \
-        -
-    } > "${task_file}"
+    echo "  → ${obj_name}"
 
-    echo "    Written: ${task_file}"
+    if [[ "${base_kind}" == "Task" ]]; then
+      # Render the Task variant (used for the task/ output and/or as the
+      # source for StepAction derivation).
+      task_dir="${TASK_DIR}/${obj_name}"
+      task_file="${task_dir}/${obj_name}.yaml"
+      mkdir -p "${task_dir}"
+      render_with_variant "${base_file}" ".spec.steps[].image" \
+        "${obj_name}" "${image}" "${description_suffix}" "${display_suffix}" > "${task_file}"
+
+      if [[ "${want_task}" == true ]]; then
+        [[ -n "${suffix}" ]] && variant_readme "${TASK_DIR}/${name}" "${task_dir}" "${name}" "${obj_name}" "task"
+        echo "    Task: ${task_file}"
+      fi
+
+      if [[ "${want_stepaction}" == true ]]; then
+        sa_dir="${STEPACTION_DIR}/${obj_name}"
+        sa_file="${sa_dir}/${obj_name}.yaml"
+        mkdir -p "${sa_dir}"
+        "${PYRUN[@]}" "${SCRIPT_DIR}/generate-stepaction.py" "${task_file}" "${sa_file}"
+        [[ -n "${suffix}" ]] && variant_readme "${STEPACTION_DIR}/${name}" "${sa_dir}" "${name}" "${obj_name}" "stepaction"
+        echo "    StepAction (derived): ${sa_file}"
+      fi
+
+      # If task output is not wanted, drop the intermediate task file.
+      if [[ "${want_task}" != true ]]; then
+        rm -rf "${task_dir}"
+      fi
+
+    elif [[ "${base_kind}" == "StepAction" ]]; then
+      if [[ "${want_stepaction}" == true ]]; then
+        sa_dir="${STEPACTION_DIR}/${obj_name}"
+        sa_file="${sa_dir}/${obj_name}.yaml"
+        mkdir -p "${sa_dir}"
+        render_with_variant "${base_file}" ".spec.image" \
+          "${obj_name}" "${image}" "${description_suffix}" "${display_suffix}" > "${sa_file}"
+        [[ -n "${suffix}" ]] && variant_readme "${STEPACTION_DIR}/${name}" "${sa_dir}" "${name}" "${obj_name}" "stepaction"
+        echo "    StepAction: ${sa_file}"
+      fi
+    else
+      echo "Error: unsupported base kind '${base_kind}' in ${base_file}" >&2
+      exit 1
+    fi
   done
 done
 
-echo "Done generating task variants."
+echo "Done generating catalog artifacts."

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -149,7 +149,7 @@ Output the two sections separated by the exact string ---SEPARATOR--- on its own
     LLM_OUTPUT=$(gh copilot -p "${PROMPT}" 2>/dev/null || echo "")
 
     if [[ -n "${LLM_OUTPUT}" ]]; then
-        AH_CHANGES=$(echo "${LLM_OUTPUT}" | sed -n '/^ *- kind:/,/---SEPARATOR---/p' | grep -v '^---SEPARATOR---')
+        AH_CHANGES=$(echo "${LLM_OUTPUT}" | sed -n '/^ *- kind:/,/---SEPARATOR---/p' | grep -v '^---SEPARATOR---' | sed 's/^[[:space:]]*//')
         TAG_MESSAGE=$(echo "${LLM_OUTPUT}" | sed -n '/^---SEPARATOR---$/,$ p' | tail -n +2 | sed '/^$/d; /^[[:space:]]*$/d' | sed '1{/^$/d}')
     else
         echo "Warning: gh copilot not available, falling back to git log"
@@ -163,11 +163,11 @@ if [[ "${USE_LLM}" != true ]]; then
     while IFS= read -r line; do
         msg="${line#* }"  # strip commit hash
         case "${msg}" in
-            feat:*|feat\(*) AH_CHANGES="${AH_CHANGES}      - kind: added\n        description: ${msg#*: }\n" ;;
-            fix:*|fix\(*)   AH_CHANGES="${AH_CHANGES}      - kind: fixed\n        description: ${msg#*: }\n" ;;
-            chore:*|ci:*|build*) AH_CHANGES="${AH_CHANGES}      - kind: changed\n        description: ${msg#*: }\n" ;;
-            docs:*)         AH_CHANGES="${AH_CHANGES}      - kind: changed\n        description: ${msg#*: }\n" ;;
-            *)              AH_CHANGES="${AH_CHANGES}      - kind: changed\n        description: ${msg}\n" ;;
+            feat:*|feat\(*) AH_CHANGES="${AH_CHANGES}- kind: added\n  description: ${msg#*: }\n" ;;
+            fix:*|fix\(*)   AH_CHANGES="${AH_CHANGES}- kind: fixed\n  description: ${msg#*: }\n" ;;
+            chore:*|ci:*|build*) AH_CHANGES="${AH_CHANGES}- kind: changed\n  description: ${msg#*: }\n" ;;
+            docs:*)         AH_CHANGES="${AH_CHANGES}- kind: changed\n  description: ${msg#*: }\n" ;;
+            *)              AH_CHANGES="${AH_CHANGES}- kind: changed\n  description: ${msg}\n" ;;
         esac
     done <<< "${COMMITS}"
 
@@ -193,6 +193,17 @@ for sadir in "${ROOT_DIR}"/stepaction/*/; do
     [[ -f "${sadir}${sa}.yaml" ]] && STEPACTION_FILES+=("stepaction/${sa}/${sa}.yaml")
 done
 ALL_FILES=("${TASK_FILES[@]}" "${STEPACTION_FILES[@]}" "VERSION")
+
+# --- Inject artifacthub.io/changes into all generated YAMLs ---
+if [[ -n "${AH_CHANGES}" ]]; then
+    echo "--- Injecting artifacthub.io/changes annotation..."
+    AH_CHANGES_BLOCK="$(printf '%b' "${AH_CHANGES}")"
+    for f in "${TASK_FILES[@]}" "${STEPACTION_FILES[@]}"; do
+        AH_CHANGES_BLOCK="${AH_CHANGES_BLOCK}" yq -i \
+            '.metadata.annotations["artifacthub.io/changes"] = strenv(AH_CHANGES_BLOCK)' \
+            "${f}"
+    done
+fi
 
 echo "--- Files to commit:"
 for f in "${ALL_FILES[@]}"; do

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -112,7 +112,7 @@ fi
 # --- Bump VERSION (single source of truth) and regenerate task files ---
 echo "--- Bumping VERSION: ${CURRENT_VERSION} -> ${BARE_VERSION}"
 echo "${BARE_VERSION}" > "${ROOT_DIR}/VERSION"
-echo "--- Running hack/generate.sh to regenerate task files at ${BARE_VERSION}..."
+echo "--- Running hack/generate.sh to regenerate task and stepaction files at ${BARE_VERSION}..."
 "${SCRIPT_DIR}/generate.sh"
 
 # --- Generate changelog ---
@@ -186,7 +186,13 @@ echo "${TAG_MESSAGE}"
 echo ""
 
 # --- Files that change at release time ---
-ALL_FILES=("${TASK_FILES[@]}" "VERSION")
+# Discover generated task and stepaction files plus the VERSION marker.
+STEPACTION_FILES=()
+for sadir in "${ROOT_DIR}"/stepaction/*/; do
+    sa=$(basename "${sadir}")
+    [[ -f "${sadir}${sa}.yaml" ]] && STEPACTION_FILES+=("stepaction/${sa}/${sa}.yaml")
+done
+ALL_FILES=("${TASK_FILES[@]}" "${STEPACTION_FILES[@]}" "VERSION")
 
 echo "--- Files to commit:"
 for f in "${ALL_FILES[@]}"; do
@@ -196,16 +202,16 @@ echo ""
 
 if [[ "${DRY_RUN}" == true ]]; then
     echo "--- Dry run: showing changes ---"
-    git --no-pager diff -- VERSION task/ || true
+    git --no-pager diff -- VERSION task/ stepaction/ || true
     echo ""
     echo "--- Restoring working tree (dry run) ---"
-    git checkout -- VERSION task/ 2>/dev/null || true
+    git checkout -- VERSION task/ stepaction/ 2>/dev/null || true
     echo "Dry run complete. Run without --dry-run to apply."
     exit 0
 fi
 
 echo "--- Committing..."
-git add VERSION task/
+git add VERSION task/ stepaction/
 git commit --signoff --message "chore: bump version to ${VERSION}"
 
 echo "--- Pushing to main..."

--- a/stepaction/artifacthub-repo.yaml
+++ b/stepaction/artifacthub-repo.yaml
@@ -1,0 +1,9 @@
+# Artifact Hub repository metadata file for the golang StepActions.
+# NOTE: replace repositoryID with the value Artifact Hub assigns when the
+# StepActions repository is registered, to claim ownership.
+repositoryID: c7e64ea4-71fa-491c-b9bf-a61c72513f75
+owners: # (optional, used to claim repository ownership)
+  - name: Vincent Demeester
+    email: vincent@sbr.pm
+  - name: vinamra28
+    email: jvinamra776@gmail.com

--- a/stepaction/artifacthub-repo.yaml
+++ b/stepaction/artifacthub-repo.yaml
@@ -1,7 +1,5 @@
 # Artifact Hub repository metadata file for the golang StepActions.
-# NOTE: replace repositoryID with the value Artifact Hub assigns when the
-# StepActions repository is registered, to claim ownership.
-repositoryID: c7e64ea4-71fa-491c-b9bf-a61c72513f75
+repositoryID: 82f59bf4-b291-41d0-960b-d52bbafa713c
 owners: # (optional, used to claim repository ownership)
   - name: Vincent Demeester
     email: vincent@sbr.pm

--- a/stepaction/golang-build-alpine/README.md
+++ b/stepaction/golang-build-alpine/README.md
@@ -1,0 +1,61 @@
+# Golang Build (StepAction)
+
+This StepAction builds Go packages. It is the StepAction form of the
+`golang-build` Task, for composing into a single Task with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-build-alpine/golang-build-alpine.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `package` | Base package to build in | _(required)_ |
+| `packages` | Packages to build | `./cmd/...` |
+| `version` | Golang version to use for builds | `1.26` |
+| `flags` | Flags to use for the build command | `-v` |
+| `GOOS` | Target operating system | `linux` |
+| `GOARCH` | Target architecture | `amd64` |
+| `GO111MODULE` | Value of module support | `auto` |
+| `GOCACHE` | Go caching directory path | `""` |
+| `GOMODCACHE` | Go mod caching directory path | `""` |
+| `CGO_ENABLED` | Toggle cgo tool during build. Use `0` to disable (for static builds). | `""` |
+| `GOSUMDB` | Go checksum database URL. Use `off` to disable checksum validation. | `""` |
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+Compose with other steps in a single Task:
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: build-my-code
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: build
+        ref:
+          name: golang-build-alpine
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+          - name: package
+            value: github.com/my-org/my-project
+```

--- a/stepaction/golang-build-alpine/golang-build-alpine.yaml
+++ b/stepaction/golang-build-alpine/golang-build-alpine.yaml
@@ -41,7 +41,7 @@ spec:
     description: golang version to use for builds
     default: "1.26"
   - name: flags
-    description: flags to use for the test command
+    description: flags to use for the build command
     default: -v
   - name: GOOS
     description: running program's operating system target

--- a/stepaction/golang-build-alpine/golang-build-alpine.yaml
+++ b/stepaction/golang-build-alpine/golang-build-alpine.yaml
@@ -1,0 +1,92 @@
+# Generated from task/golang-build-alpine/golang-build-alpine.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-build-alpine
+  labels:
+    app.kubernetes.io/version: "1.2.0"
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Build Tools
+    tekton.dev/displayName: golang build (alpine)
+    tekton.dev/pipelines.minVersion: "1.0.0"
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: build-tool
+spec:
+  description: This StepAction is a Golang step to build Go projects. Uses the Alpine-based
+    Go image for smaller footprint.
+  params:
+  - name: source-path
+    description: Path to the Go source code to operate on.
+    type: string
+  - name: package
+    description: base package to build in
+  - name: packages
+    description: 'packages to build (default: ./cmd/...)'
+    default: ./cmd/...
+  - name: version
+    description: golang version to use for builds
+    default: "1.26"
+  - name: flags
+    description: flags to use for the test command
+    default: -v
+  - name: GOOS
+    description: running program's operating system target
+    default: linux
+  - name: GOARCH
+    description: running program's architecture target
+    default: amd64
+  - name: GO111MODULE
+    description: value of module support
+    default: auto
+  - name: GOCACHE
+    description: Go caching directory path
+    default: ""
+  - name: GOMODCACHE
+    description: Go mod caching directory path
+    default: ""
+  - name: CGO_ENABLED
+    description: Toggle cgo tool during Go build. Use value '0' to disable cgo (for
+      static builds).
+    default: ""
+  - name: GOSUMDB
+    description: Go checksum database url. Use value 'off' to disable checksum validation.
+    default: ""
+  image: docker.io/library/golang:$(params.version)-alpine
+  workingDir: $(params.source-path)
+  env:
+  - name: GOOS
+    value: $(params.GOOS)
+  - name: GOARCH
+    value: $(params.GOARCH)
+  - name: GO111MODULE
+    value: $(params.GO111MODULE)
+  - name: GOCACHE
+    value: $(params.GOCACHE)
+  - name: GOMODCACHE
+    value: $(params.GOMODCACHE)
+  - name: CGO_ENABLED
+    value: $(params.CGO_ENABLED)
+  - name: GOSUMDB
+    value: $(params.GOSUMDB)
+  script: |
+    if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+      SRC_PATH="$GOPATH/src/$(params.package)"
+      mkdir -p $SRC_PATH
+      cp -R "$(params.source-path)"/* $SRC_PATH
+      cd $SRC_PATH
+    fi
+    go build $(params.flags) $(params.packages)

--- a/stepaction/golang-build-alpine/golang-build-alpine.yaml
+++ b/stepaction/golang-build-alpine/golang-build-alpine.yaml
@@ -82,11 +82,19 @@ spec:
     value: $(params.CGO_ENABLED)
   - name: GOSUMDB
     value: $(params.GOSUMDB)
+  - name: PACKAGE
+    value: $(params.package)
+  - name: PACKAGES
+    value: $(params.packages)
+  - name: FLAGS
+    value: $(params.flags)
+  - name: SOURCE_PATH
+    value: $(params.source-path)
   script: |
-    if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-      SRC_PATH="$GOPATH/src/$(params.package)"
+    if [ ! -e $GOPATH/src/${PACKAGE}/go.mod ];then
+      SRC_PATH="$GOPATH/src/${PACKAGE}"
       mkdir -p $SRC_PATH
-      cp -R "$(params.source-path)"/* $SRC_PATH
+      cp -R "${SOURCE_PATH}"/* $SRC_PATH
       cd $SRC_PATH
     fi
-    go build $(params.flags) $(params.packages)
+    go build ${FLAGS} ${PACKAGES}

--- a/stepaction/golang-build/README.md
+++ b/stepaction/golang-build/README.md
@@ -1,0 +1,61 @@
+# Golang Build (StepAction)
+
+This StepAction builds Go packages. It is the StepAction form of the
+`golang-build` Task, for composing into a single Task with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-build/golang-build.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `package` | Base package to build in | _(required)_ |
+| `packages` | Packages to build | `./cmd/...` |
+| `version` | Golang version to use for builds | `1.26` |
+| `flags` | Flags to use for the build command | `-v` |
+| `GOOS` | Target operating system | `linux` |
+| `GOARCH` | Target architecture | `amd64` |
+| `GO111MODULE` | Value of module support | `auto` |
+| `GOCACHE` | Go caching directory path | `""` |
+| `GOMODCACHE` | Go mod caching directory path | `""` |
+| `CGO_ENABLED` | Toggle cgo tool during build. Use `0` to disable (for static builds). | `""` |
+| `GOSUMDB` | Go checksum database URL. Use `off` to disable checksum validation. | `""` |
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+Compose with other steps in a single Task:
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: build-my-code
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: build
+        ref:
+          name: golang-build
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+          - name: package
+            value: github.com/my-org/my-project
+```

--- a/stepaction/golang-build/golang-build.yaml
+++ b/stepaction/golang-build/golang-build.yaml
@@ -40,7 +40,7 @@ spec:
     description: golang version to use for builds
     default: "1.26"
   - name: flags
-    description: flags to use for the test command
+    description: flags to use for the build command
     default: -v
   - name: GOOS
     description: running program's operating system target

--- a/stepaction/golang-build/golang-build.yaml
+++ b/stepaction/golang-build/golang-build.yaml
@@ -1,0 +1,91 @@
+# Generated from task/golang-build/golang-build.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-build
+  labels:
+    app.kubernetes.io/version: "1.2.0"
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Build Tools
+    tekton.dev/displayName: golang build
+    tekton.dev/pipelines.minVersion: "1.0.0"
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: build-tool
+spec:
+  description: This StepAction is a Golang step to build Go projects.
+  params:
+  - name: source-path
+    description: Path to the Go source code to operate on.
+    type: string
+  - name: package
+    description: base package to build in
+  - name: packages
+    description: 'packages to build (default: ./cmd/...)'
+    default: ./cmd/...
+  - name: version
+    description: golang version to use for builds
+    default: "1.26"
+  - name: flags
+    description: flags to use for the test command
+    default: -v
+  - name: GOOS
+    description: running program's operating system target
+    default: linux
+  - name: GOARCH
+    description: running program's architecture target
+    default: amd64
+  - name: GO111MODULE
+    description: value of module support
+    default: auto
+  - name: GOCACHE
+    description: Go caching directory path
+    default: ""
+  - name: GOMODCACHE
+    description: Go mod caching directory path
+    default: ""
+  - name: CGO_ENABLED
+    description: Toggle cgo tool during Go build. Use value '0' to disable cgo (for
+      static builds).
+    default: ""
+  - name: GOSUMDB
+    description: Go checksum database url. Use value 'off' to disable checksum validation.
+    default: ""
+  image: docker.io/library/golang:$(params.version)
+  workingDir: $(params.source-path)
+  env:
+  - name: GOOS
+    value: $(params.GOOS)
+  - name: GOARCH
+    value: $(params.GOARCH)
+  - name: GO111MODULE
+    value: $(params.GO111MODULE)
+  - name: GOCACHE
+    value: $(params.GOCACHE)
+  - name: GOMODCACHE
+    value: $(params.GOMODCACHE)
+  - name: CGO_ENABLED
+    value: $(params.CGO_ENABLED)
+  - name: GOSUMDB
+    value: $(params.GOSUMDB)
+  script: |
+    if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+      SRC_PATH="$GOPATH/src/$(params.package)"
+      mkdir -p $SRC_PATH
+      cp -R "$(params.source-path)"/* $SRC_PATH
+      cd $SRC_PATH
+    fi
+    go build $(params.flags) $(params.packages)

--- a/stepaction/golang-build/golang-build.yaml
+++ b/stepaction/golang-build/golang-build.yaml
@@ -81,11 +81,19 @@ spec:
     value: $(params.CGO_ENABLED)
   - name: GOSUMDB
     value: $(params.GOSUMDB)
+  - name: PACKAGE
+    value: $(params.package)
+  - name: PACKAGES
+    value: $(params.packages)
+  - name: FLAGS
+    value: $(params.flags)
+  - name: SOURCE_PATH
+    value: $(params.source-path)
   script: |
-    if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-      SRC_PATH="$GOPATH/src/$(params.package)"
+    if [ ! -e $GOPATH/src/${PACKAGE}/go.mod ];then
+      SRC_PATH="$GOPATH/src/${PACKAGE}"
       mkdir -p $SRC_PATH
-      cp -R "$(params.source-path)"/* $SRC_PATH
+      cp -R "${SOURCE_PATH}"/* $SRC_PATH
       cd $SRC_PATH
     fi
-    go build $(params.flags) $(params.packages)
+    go build ${FLAGS} ${PACKAGES}

--- a/stepaction/golang-fix-alpine/README.md
+++ b/stepaction/golang-fix-alpine/README.md
@@ -1,0 +1,49 @@
+# Golang Fix (StepAction)
+
+This StepAction runs `go fix` to modernize Go source code to use newer language
+and library features. The modernizing `go fix` requires Go 1.26+. It is a
+StepAction-only tool, designed to be composed with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-fix-alpine/golang-fix-alpine.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `packages` | Packages to fix | `./...` |
+| `version` | Golang version to use (1.26+ required) | `1.26` |
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: fix-code
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: fix
+        ref:
+          name: golang-fix-alpine
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+```

--- a/stepaction/golang-fix-alpine/golang-fix-alpine.yaml
+++ b/stepaction/golang-fix-alpine/golang-fix-alpine.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang fix (alpine)
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: modernize
   labels:

--- a/stepaction/golang-fix-alpine/golang-fix-alpine.yaml
+++ b/stepaction/golang-fix-alpine/golang-fix-alpine.yaml
@@ -1,0 +1,43 @@
+# Generated from base/golang-fix.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-fix-alpine
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Code Quality
+    tekton.dev/displayName: golang fix (alpine)
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: modernize
+  labels:
+    app.kubernetes.io/version: 1.2.0
+spec:
+  description: This StepAction runs 'go fix' to modernize Go source code to use newer language and library features (Go 1.26+). Uses the Alpine-based Go image for smaller footprint.
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: packages
+      description: packages to fix
+      default: ./...
+    - name: version
+      description: golang version to use (1.26+ required for the modernizing 'go fix')
+      default: "1.26"
+  image: docker.io/library/golang:$(params.version)-alpine
+  workingDir: $(params.source-path)
+  script: |
+    go fix $(params.packages)

--- a/stepaction/golang-fix-alpine/golang-fix-alpine.yaml
+++ b/stepaction/golang-fix-alpine/golang-fix-alpine.yaml
@@ -39,5 +39,8 @@ spec:
       default: "1.26"
   image: docker.io/library/golang:$(params.version)-alpine
   workingDir: $(params.source-path)
+  env:
+    - name: PARAM_PACKAGES
+      value: $(params.packages)
   script: |
-    go fix $(params.packages)
+    go fix ${PARAM_PACKAGES}

--- a/stepaction/golang-fix/README.md
+++ b/stepaction/golang-fix/README.md
@@ -1,0 +1,49 @@
+# Golang Fix (StepAction)
+
+This StepAction runs `go fix` to modernize Go source code to use newer language
+and library features. The modernizing `go fix` requires Go 1.26+. It is a
+StepAction-only tool, designed to be composed with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-fix/golang-fix.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `packages` | Packages to fix | `./...` |
+| `version` | Golang version to use (1.26+ required) | `1.26` |
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: fix-code
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: fix
+        ref:
+          name: golang-fix
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+```

--- a/stepaction/golang-fix/golang-fix.yaml
+++ b/stepaction/golang-fix/golang-fix.yaml
@@ -1,0 +1,43 @@
+# Generated from base/golang-fix.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-fix
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Code Quality
+    tekton.dev/displayName: golang fix
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: modernize
+  labels:
+    app.kubernetes.io/version: 1.2.0
+spec:
+  description: This StepAction runs 'go fix' to modernize Go source code to use newer language and library features (Go 1.26+).
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: packages
+      description: packages to fix
+      default: ./...
+    - name: version
+      description: golang version to use (1.26+ required for the modernizing 'go fix')
+      default: "1.26"
+  image: docker.io/library/golang:$(params.version)
+  workingDir: $(params.source-path)
+  script: |
+    go fix $(params.packages)

--- a/stepaction/golang-fix/golang-fix.yaml
+++ b/stepaction/golang-fix/golang-fix.yaml
@@ -39,5 +39,8 @@ spec:
       default: "1.26"
   image: docker.io/library/golang:$(params.version)
   workingDir: $(params.source-path)
+  env:
+    - name: PARAM_PACKAGES
+      value: $(params.packages)
   script: |
-    go fix $(params.packages)
+    go fix ${PARAM_PACKAGES}

--- a/stepaction/golang-fix/golang-fix.yaml
+++ b/stepaction/golang-fix/golang-fix.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang fix
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: modernize
   labels:

--- a/stepaction/golang-fmt-alpine/README.md
+++ b/stepaction/golang-fmt-alpine/README.md
@@ -18,6 +18,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/
 |-----------|-------------|---------|
 | `source-path` | Path to the Go source code to operate on | _(required)_ |
 | `paths` | Paths to check for formatting | `.` |
+| `skip-dirs` | Directories to exclude (pipe-separated regex) | `vendor` |
 | `version` | Golang version to use | `1.26` |
 
 ## Platforms

--- a/stepaction/golang-fmt-alpine/README.md
+++ b/stepaction/golang-fmt-alpine/README.md
@@ -1,0 +1,49 @@
+# Golang Fmt (StepAction)
+
+This StepAction checks that Go source code is formatted with `gofmt` and fails
+if any file needs formatting. It is a StepAction-only tool, designed to be
+composed with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-fmt-alpine/golang-fmt-alpine.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `paths` | Paths to check for formatting | `.` |
+| `version` | Golang version to use | `1.26` |
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: fmt-check
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: fmt
+        ref:
+          name: golang-fmt-alpine
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+```

--- a/stepaction/golang-fmt-alpine/golang-fmt-alpine.yaml
+++ b/stepaction/golang-fmt-alpine/golang-fmt-alpine.yaml
@@ -1,0 +1,51 @@
+# Generated from base/golang-fmt.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-fmt-alpine
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Code Quality
+    tekton.dev/displayName: golang fmt (alpine)
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: lint
+  labels:
+    app.kubernetes.io/version: 1.2.0
+spec:
+  description: This StepAction checks that Go source code is formatted with gofmt and fails if any file needs formatting. Uses the Alpine-based Go image for smaller footprint.
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: paths
+      description: paths to check for formatting
+      default: .
+    - name: version
+      description: golang version to use
+      default: "1.26"
+  image: docker.io/library/golang:$(params.version)-alpine
+  workingDir: $(params.source-path)
+  script: |
+    unformatted=$(gofmt -l $(params.paths))
+    if [ -n "${unformatted}" ]; then
+      echo "The following files are not formatted:"
+      echo "${unformatted}"
+      echo ""
+      echo "Run 'gofmt -w' on them to fix."
+      exit 1
+    fi
+    echo "All Go files are correctly formatted."

--- a/stepaction/golang-fmt-alpine/golang-fmt-alpine.yaml
+++ b/stepaction/golang-fmt-alpine/golang-fmt-alpine.yaml
@@ -39,8 +39,11 @@ spec:
       default: "1.26"
   image: docker.io/library/golang:$(params.version)-alpine
   workingDir: $(params.source-path)
+  env:
+    - name: PARAM_PATHS
+      value: $(params.paths)
   script: |
-    unformatted=$(gofmt -l $(params.paths))
+    unformatted=$(gofmt -l ${PARAM_PATHS})
     if [ -n "${unformatted}" ]; then
       echo "The following files are not formatted:"
       echo "${unformatted}"

--- a/stepaction/golang-fmt-alpine/golang-fmt-alpine.yaml
+++ b/stepaction/golang-fmt-alpine/golang-fmt-alpine.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang fmt (alpine)
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
   labels:
@@ -49,7 +49,7 @@ spec:
       value: $(params.skip-dirs)
   script: |
     if [ -n "${SKIP_DIRS}" ]; then
-      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs gofmt -l 2>/dev/null)
+      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "(^|/)${SKIP_DIRS}/" | xargs gofmt -l 2>/dev/null)
     else
       unformatted=$(gofmt -l ${PARAM_PATHS})
     fi

--- a/stepaction/golang-fmt/README.md
+++ b/stepaction/golang-fmt/README.md
@@ -18,6 +18,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/
 |-----------|-------------|---------|
 | `source-path` | Path to the Go source code to operate on | _(required)_ |
 | `paths` | Paths to check for formatting | `.` |
+| `skip-dirs` | Directories to exclude (pipe-separated regex) | `vendor` |
 | `version` | Golang version to use | `1.26` |
 
 ## Platforms

--- a/stepaction/golang-fmt/README.md
+++ b/stepaction/golang-fmt/README.md
@@ -1,0 +1,49 @@
+# Golang Fmt (StepAction)
+
+This StepAction checks that Go source code is formatted with `gofmt` and fails
+if any file needs formatting. It is a StepAction-only tool, designed to be
+composed with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-fmt/golang-fmt.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `paths` | Paths to check for formatting | `.` |
+| `version` | Golang version to use | `1.26` |
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: fmt-check
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: fmt
+        ref:
+          name: golang-fmt
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+```

--- a/stepaction/golang-fmt/golang-fmt.yaml
+++ b/stepaction/golang-fmt/golang-fmt.yaml
@@ -1,0 +1,51 @@
+# Generated from base/golang-fmt.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-fmt
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Code Quality
+    tekton.dev/displayName: golang fmt
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: lint
+  labels:
+    app.kubernetes.io/version: 1.2.0
+spec:
+  description: This StepAction checks that Go source code is formatted with gofmt and fails if any file needs formatting.
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: paths
+      description: paths to check for formatting
+      default: .
+    - name: version
+      description: golang version to use
+      default: "1.26"
+  image: docker.io/library/golang:$(params.version)
+  workingDir: $(params.source-path)
+  script: |
+    unformatted=$(gofmt -l $(params.paths))
+    if [ -n "${unformatted}" ]; then
+      echo "The following files are not formatted:"
+      echo "${unformatted}"
+      echo ""
+      echo "Run 'gofmt -w' on them to fix."
+      exit 1
+    fi
+    echo "All Go files are correctly formatted."

--- a/stepaction/golang-fmt/golang-fmt.yaml
+++ b/stepaction/golang-fmt/golang-fmt.yaml
@@ -34,6 +34,9 @@ spec:
     - name: paths
       description: paths to check for formatting
       default: .
+    - name: skip-dirs
+      description: directories to exclude (pipe-separated regex, e.g. 'vendor|third_party')
+      default: vendor
     - name: version
       description: golang version to use
       default: "1.26"
@@ -42,8 +45,14 @@ spec:
   env:
     - name: PARAM_PATHS
       value: $(params.paths)
+    - name: SKIP_DIRS
+      value: $(params.skip-dirs)
   script: |
-    unformatted=$(gofmt -l ${PARAM_PATHS})
+    if [ -n "${SKIP_DIRS}" ]; then
+      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs gofmt -l 2>/dev/null)
+    else
+      unformatted=$(gofmt -l ${PARAM_PATHS})
+    fi
     if [ -n "${unformatted}" ]; then
       echo "The following files are not formatted:"
       echo "${unformatted}"

--- a/stepaction/golang-fmt/golang-fmt.yaml
+++ b/stepaction/golang-fmt/golang-fmt.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang fmt
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
   labels:
@@ -49,7 +49,7 @@ spec:
       value: $(params.skip-dirs)
   script: |
     if [ -n "${SKIP_DIRS}" ]; then
-      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs gofmt -l 2>/dev/null)
+      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "(^|/)${SKIP_DIRS}/" | xargs gofmt -l 2>/dev/null)
     else
       unformatted=$(gofmt -l ${PARAM_PATHS})
     fi

--- a/stepaction/golang-fmt/golang-fmt.yaml
+++ b/stepaction/golang-fmt/golang-fmt.yaml
@@ -39,8 +39,11 @@ spec:
       default: "1.26"
   image: docker.io/library/golang:$(params.version)
   workingDir: $(params.source-path)
+  env:
+    - name: PARAM_PATHS
+      value: $(params.paths)
   script: |
-    unformatted=$(gofmt -l $(params.paths))
+    unformatted=$(gofmt -l ${PARAM_PATHS})
     if [ -n "${unformatted}" ]; then
       echo "The following files are not formatted:"
       echo "${unformatted}"

--- a/stepaction/golang-goimports-alpine/README.md
+++ b/stepaction/golang-goimports-alpine/README.md
@@ -1,0 +1,61 @@
+# Golang Goimports (StepAction)
+
+This StepAction checks that Go source code is formatted and imports are
+organized using [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports).
+It is a superset of `gofmt` — it also groups and sorts import statements.
+It is a StepAction-only tool, designed to be composed with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-goimports-alpine/golang-goimports-alpine.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `paths` | Paths to check for formatting | `.` |
+| `skip-dirs` | Directories to exclude (pipe-separated regex) | `vendor` |
+| `goimports-version` | Version of goimports to install | `latest` |
+| `version` | Golang version to use | `1.26` |
+
+> Installs `goimports` at runtime via `go install`, so the step needs network
+> access to the Go module proxy.
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: imports-check
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: goimports
+        ref:
+          name: golang-goimports-alpine
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+```
+
+## gofmt vs goimports
+
+Use `golang-fmt` if your project only enforces formatting. Use
+`golang-goimports` if your project also enforces import grouping/ordering
+(most Go projects do). Do not use both — goimports is a strict superset.

--- a/stepaction/golang-goimports-alpine/golang-goimports-alpine.yaml
+++ b/stepaction/golang-goimports-alpine/golang-goimports-alpine.yaml
@@ -1,8 +1,8 @@
-# Generated from base/golang-fmt.yaml — do not edit directly.
+# Generated from base/golang-goimports.yaml — do not edit directly.
 apiVersion: tekton.dev/v1beta1
 kind: StepAction
 metadata:
-  name: golang-fmt-alpine
+  name: golang-goimports-alpine
   annotations:
     artifacthub.io/category: integration-delivery
     artifacthub.io/license: Apache-2.0
@@ -19,14 +19,14 @@ metadata:
     tekton.dev/catalog-support-tier: verified
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
-    tekton.dev/displayName: golang fmt (alpine)
+    tekton.dev/displayName: golang goimports (alpine)
     tekton.dev/pipelines.minVersion: 0.40.0
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
   labels:
     app.kubernetes.io/version: 1.2.0
 spec:
-  description: This StepAction checks that Go source code is formatted with gofmt and fails if any file needs formatting. Uses the Alpine-based Go image for smaller footprint.
+  description: This StepAction checks that Go source code is formatted and imports are organized using goimports. It is a superset of gofmt — it also groups and sorts import statements. Uses the Alpine-based Go image for smaller footprint.
   params:
     - name: source-path
       description: Path to the Go source code to operate on.
@@ -37,27 +37,36 @@ spec:
     - name: skip-dirs
       description: directories to exclude (pipe-separated regex, e.g. 'vendor|third_party')
       default: vendor
+    - name: goimports-version
+      description: version of goimports to install
+      default: latest
     - name: version
       description: golang version to use
       default: "1.26"
   image: docker.io/library/golang:$(params.version)-alpine
   workingDir: $(params.source-path)
   env:
+    - name: GOBIN
+      value: /tekton/home/go/bin
     - name: PARAM_PATHS
       value: $(params.paths)
     - name: SKIP_DIRS
       value: $(params.skip-dirs)
+    - name: GOIMPORTS_VERSION
+      value: $(params.goimports-version)
   script: |
+    export PATH="${GOBIN}:${PATH}"
+    go install golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}
     if [ -n "${SKIP_DIRS}" ]; then
-      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs gofmt -l 2>/dev/null)
+      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs goimports -l 2>/dev/null)
     else
-      unformatted=$(gofmt -l ${PARAM_PATHS})
+      unformatted=$(goimports -l ${PARAM_PATHS})
     fi
     if [ -n "${unformatted}" ]; then
-      echo "The following files are not formatted:"
+      echo "The following files have incorrect formatting or imports:"
       echo "${unformatted}"
       echo ""
-      echo "Run 'gofmt -w' on them to fix."
+      echo "Run 'goimports -w' on them to fix."
       exit 1
     fi
-    echo "All Go files are correctly formatted."
+    echo "All Go files have correct formatting and imports."

--- a/stepaction/golang-goimports-alpine/golang-goimports-alpine.yaml
+++ b/stepaction/golang-goimports-alpine/golang-goimports-alpine.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang goimports (alpine)
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
   labels:
@@ -58,7 +58,7 @@ spec:
     export PATH="${GOBIN}:${PATH}"
     go install golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}
     if [ -n "${SKIP_DIRS}" ]; then
-      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs goimports -l 2>/dev/null)
+      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "(^|/)${SKIP_DIRS}/" | xargs goimports -l 2>/dev/null)
     else
       unformatted=$(goimports -l ${PARAM_PATHS})
     fi

--- a/stepaction/golang-goimports/README.md
+++ b/stepaction/golang-goimports/README.md
@@ -1,0 +1,61 @@
+# Golang Goimports (StepAction)
+
+This StepAction checks that Go source code is formatted and imports are
+organized using [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports).
+It is a superset of `gofmt` — it also groups and sorts import statements.
+It is a StepAction-only tool, designed to be composed with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-goimports/golang-goimports.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `paths` | Paths to check for formatting | `.` |
+| `skip-dirs` | Directories to exclude (pipe-separated regex) | `vendor` |
+| `goimports-version` | Version of goimports to install | `latest` |
+| `version` | Golang version to use | `1.26` |
+
+> Installs `goimports` at runtime via `go install`, so the step needs network
+> access to the Go module proxy.
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: imports-check
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: goimports
+        ref:
+          name: golang-goimports
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+```
+
+## gofmt vs goimports
+
+Use `golang-fmt` if your project only enforces formatting. Use
+`golang-goimports` if your project also enforces import grouping/ordering
+(most Go projects do). Do not use both — goimports is a strict superset.

--- a/stepaction/golang-goimports/golang-goimports.yaml
+++ b/stepaction/golang-goimports/golang-goimports.yaml
@@ -1,8 +1,8 @@
-# Generated from base/golang-fmt.yaml — do not edit directly.
+# Generated from base/golang-goimports.yaml — do not edit directly.
 apiVersion: tekton.dev/v1beta1
 kind: StepAction
 metadata:
-  name: golang-fmt-alpine
+  name: golang-goimports
   annotations:
     artifacthub.io/category: integration-delivery
     artifacthub.io/license: Apache-2.0
@@ -19,14 +19,14 @@ metadata:
     tekton.dev/catalog-support-tier: verified
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
-    tekton.dev/displayName: golang fmt (alpine)
+    tekton.dev/displayName: golang goimports
     tekton.dev/pipelines.minVersion: 0.40.0
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
   labels:
     app.kubernetes.io/version: 1.2.0
 spec:
-  description: This StepAction checks that Go source code is formatted with gofmt and fails if any file needs formatting. Uses the Alpine-based Go image for smaller footprint.
+  description: This StepAction checks that Go source code is formatted and imports are organized using goimports. It is a superset of gofmt — it also groups and sorts import statements.
   params:
     - name: source-path
       description: Path to the Go source code to operate on.
@@ -37,27 +37,36 @@ spec:
     - name: skip-dirs
       description: directories to exclude (pipe-separated regex, e.g. 'vendor|third_party')
       default: vendor
+    - name: goimports-version
+      description: version of goimports to install
+      default: latest
     - name: version
       description: golang version to use
       default: "1.26"
-  image: docker.io/library/golang:$(params.version)-alpine
+  image: docker.io/library/golang:$(params.version)
   workingDir: $(params.source-path)
   env:
+    - name: GOBIN
+      value: /tekton/home/go/bin
     - name: PARAM_PATHS
       value: $(params.paths)
     - name: SKIP_DIRS
       value: $(params.skip-dirs)
+    - name: GOIMPORTS_VERSION
+      value: $(params.goimports-version)
   script: |
+    export PATH="${GOBIN}:${PATH}"
+    go install golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}
     if [ -n "${SKIP_DIRS}" ]; then
-      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs gofmt -l 2>/dev/null)
+      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs goimports -l 2>/dev/null)
     else
-      unformatted=$(gofmt -l ${PARAM_PATHS})
+      unformatted=$(goimports -l ${PARAM_PATHS})
     fi
     if [ -n "${unformatted}" ]; then
-      echo "The following files are not formatted:"
+      echo "The following files have incorrect formatting or imports:"
       echo "${unformatted}"
       echo ""
-      echo "Run 'gofmt -w' on them to fix."
+      echo "Run 'goimports -w' on them to fix."
       exit 1
     fi
-    echo "All Go files are correctly formatted."
+    echo "All Go files have correct formatting and imports."

--- a/stepaction/golang-goimports/golang-goimports.yaml
+++ b/stepaction/golang-goimports/golang-goimports.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang goimports
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
   labels:
@@ -58,7 +58,7 @@ spec:
     export PATH="${GOBIN}:${PATH}"
     go install golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}
     if [ -n "${SKIP_DIRS}" ]; then
-      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "^./(${SKIP_DIRS})/" | xargs goimports -l 2>/dev/null)
+      unformatted=$(find ${PARAM_PATHS} -name '*.go' | grep -Ev "(^|/)${SKIP_DIRS}/" | xargs goimports -l 2>/dev/null)
     else
       unformatted=$(goimports -l ${PARAM_PATHS})
     fi

--- a/stepaction/golang-test-alpine/README.md
+++ b/stepaction/golang-test-alpine/README.md
@@ -1,0 +1,60 @@
+# Golang Test (StepAction)
+
+This StepAction runs Go tests. It is the StepAction form of the `golang-test`
+Task, for composing into a single Task with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-test-alpine/golang-test-alpine.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `package` | Package (and its children) under test | _(required)_ |
+| `packages` | Packages to test | `./...` |
+| `context` | Path to the directory to use as context | `.` |
+| `version` | Golang version to use for tests | `1.26` |
+| `flags` | Flags to use for the test command | `-race -cover -v` |
+| `GOOS` | Target operating system | `linux` |
+| `GOARCH` | Target architecture | `amd64` |
+| `GO111MODULE` | Value of module support | `auto` |
+| `GOCACHE` | Go caching directory path | `""` |
+| `GOMODCACHE` | Go mod caching directory path | `""` |
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+> **Note**: Do not use the `-race` flag on `linux/s390x` — it is not supported on that platform.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: test-my-code
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: test
+        ref:
+          name: golang-test-alpine
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+          - name: package
+            value: github.com/my-org/my-project
+```

--- a/stepaction/golang-test-alpine/golang-test-alpine.yaml
+++ b/stepaction/golang-test-alpine/golang-test-alpine.yaml
@@ -1,0 +1,84 @@
+# Generated from task/golang-test-alpine/golang-test-alpine.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-test-alpine
+  labels:
+    app.kubernetes.io/version: "1.2.0"
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Testing
+    tekton.dev/displayName: golang test (alpine)
+    tekton.dev/pipelines.minVersion: "1.0.0"
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: test
+spec:
+  description: This StepAction is a Golang step to test Go projects. Uses the Alpine-based
+    Go image for smaller footprint.
+  params:
+  - name: source-path
+    description: Path to the Go source code to operate on.
+    type: string
+  - name: package
+    description: package (and its children) under test
+  - name: packages
+    description: 'packages to test (default: ./...)'
+    default: ./...
+  - name: context
+    description: path to the directory to use as context.
+    default: "."
+  - name: version
+    description: golang version to use for tests
+    default: "1.26"
+  - name: flags
+    description: flags to use for the test command
+    default: -race -cover -v
+  - name: GOOS
+    description: running program's operating system target
+    default: linux
+  - name: GOARCH
+    description: running program's architecture target
+    default: amd64
+  - name: GO111MODULE
+    description: value of module support
+    default: auto
+  - name: GOCACHE
+    description: Go caching directory path
+    default: ""
+  - name: GOMODCACHE
+    description: Go mod caching directory path
+    default: ""
+  image: docker.io/library/golang:$(params.version)-alpine
+  workingDir: $(params.source-path)
+  env:
+  - name: GOOS
+    value: $(params.GOOS)
+  - name: GOARCH
+    value: $(params.GOARCH)
+  - name: GO111MODULE
+    value: $(params.GO111MODULE)
+  - name: GOCACHE
+    value: $(params.GOCACHE)
+  - name: GOMODCACHE
+    value: $(params.GOMODCACHE)
+  script: |
+    if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+       SRC_PATH="$GOPATH/src/$(params.package)"
+       mkdir -p $SRC_PATH
+       cp -R "$(params.source-path)/$(params.context)"/* $SRC_PATH
+       cd $SRC_PATH
+    fi
+    go test $(params.flags) $(params.packages)

--- a/stepaction/golang-test-alpine/golang-test-alpine.yaml
+++ b/stepaction/golang-test-alpine/golang-test-alpine.yaml
@@ -74,11 +74,21 @@ spec:
     value: $(params.GOCACHE)
   - name: GOMODCACHE
     value: $(params.GOMODCACHE)
+  - name: PACKAGE
+    value: $(params.package)
+  - name: PACKAGES
+    value: $(params.packages)
+  - name: FLAGS
+    value: $(params.flags)
+  - name: CONTEXT
+    value: $(params.context)
+  - name: SOURCE_PATH
+    value: $(params.source-path)
   script: |
-    if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-       SRC_PATH="$GOPATH/src/$(params.package)"
+    if [ ! -e $GOPATH/src/${PACKAGE}/go.mod ];then
+       SRC_PATH="$GOPATH/src/${PACKAGE}"
        mkdir -p $SRC_PATH
-       cp -R "$(params.source-path)/$(params.context)"/* $SRC_PATH
+       cp -R "${SOURCE_PATH}/${CONTEXT}"/* $SRC_PATH
        cd $SRC_PATH
     fi
-    go test $(params.flags) $(params.packages)
+    go test ${FLAGS} ${PACKAGES}

--- a/stepaction/golang-test/README.md
+++ b/stepaction/golang-test/README.md
@@ -1,0 +1,60 @@
+# Golang Test (StepAction)
+
+This StepAction runs Go tests. It is the StepAction form of the `golang-test`
+Task, for composing into a single Task with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-test/golang-test.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `package` | Package (and its children) under test | _(required)_ |
+| `packages` | Packages to test | `./...` |
+| `context` | Path to the directory to use as context | `.` |
+| `version` | Golang version to use for tests | `1.26` |
+| `flags` | Flags to use for the test command | `-race -cover -v` |
+| `GOOS` | Target operating system | `linux` |
+| `GOARCH` | Target architecture | `amd64` |
+| `GO111MODULE` | Value of module support | `auto` |
+| `GOCACHE` | Go caching directory path | `""` |
+| `GOMODCACHE` | Go mod caching directory path | `""` |
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+> **Note**: Do not use the `-race` flag on `linux/s390x` — it is not supported on that platform.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: test-my-code
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: test
+        ref:
+          name: golang-test
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+          - name: package
+            value: github.com/my-org/my-project
+```

--- a/stepaction/golang-test/golang-test.yaml
+++ b/stepaction/golang-test/golang-test.yaml
@@ -73,11 +73,21 @@ spec:
     value: $(params.GOCACHE)
   - name: GOMODCACHE
     value: $(params.GOMODCACHE)
+  - name: PACKAGE
+    value: $(params.package)
+  - name: PACKAGES
+    value: $(params.packages)
+  - name: FLAGS
+    value: $(params.flags)
+  - name: CONTEXT
+    value: $(params.context)
+  - name: SOURCE_PATH
+    value: $(params.source-path)
   script: |
-    if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-       SRC_PATH="$GOPATH/src/$(params.package)"
+    if [ ! -e $GOPATH/src/${PACKAGE}/go.mod ];then
+       SRC_PATH="$GOPATH/src/${PACKAGE}"
        mkdir -p $SRC_PATH
-       cp -R "$(params.source-path)/$(params.context)"/* $SRC_PATH
+       cp -R "${SOURCE_PATH}/${CONTEXT}"/* $SRC_PATH
        cd $SRC_PATH
     fi
-    go test $(params.flags) $(params.packages)
+    go test ${FLAGS} ${PACKAGES}

--- a/stepaction/golang-test/golang-test.yaml
+++ b/stepaction/golang-test/golang-test.yaml
@@ -1,0 +1,83 @@
+# Generated from task/golang-test/golang-test.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-test
+  labels:
+    app.kubernetes.io/version: "1.2.0"
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Testing
+    tekton.dev/displayName: golang test
+    tekton.dev/pipelines.minVersion: "1.0.0"
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: test
+spec:
+  description: This StepAction is a Golang step to test Go projects.
+  params:
+  - name: source-path
+    description: Path to the Go source code to operate on.
+    type: string
+  - name: package
+    description: package (and its children) under test
+  - name: packages
+    description: 'packages to test (default: ./...)'
+    default: ./...
+  - name: context
+    description: path to the directory to use as context.
+    default: "."
+  - name: version
+    description: golang version to use for tests
+    default: "1.26"
+  - name: flags
+    description: flags to use for the test command
+    default: -race -cover -v
+  - name: GOOS
+    description: running program's operating system target
+    default: linux
+  - name: GOARCH
+    description: running program's architecture target
+    default: amd64
+  - name: GO111MODULE
+    description: value of module support
+    default: auto
+  - name: GOCACHE
+    description: Go caching directory path
+    default: ""
+  - name: GOMODCACHE
+    description: Go mod caching directory path
+    default: ""
+  image: docker.io/library/golang:$(params.version)
+  workingDir: $(params.source-path)
+  env:
+  - name: GOOS
+    value: $(params.GOOS)
+  - name: GOARCH
+    value: $(params.GOARCH)
+  - name: GO111MODULE
+    value: $(params.GO111MODULE)
+  - name: GOCACHE
+    value: $(params.GOCACHE)
+  - name: GOMODCACHE
+    value: $(params.GOMODCACHE)
+  script: |
+    if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+       SRC_PATH="$GOPATH/src/$(params.package)"
+       mkdir -p $SRC_PATH
+       cp -R "$(params.source-path)/$(params.context)"/* $SRC_PATH
+       cd $SRC_PATH
+    fi
+    go test $(params.flags) $(params.packages)

--- a/stepaction/golang-vet-alpine/README.md
+++ b/stepaction/golang-vet-alpine/README.md
@@ -1,0 +1,49 @@
+# Golang Vet (StepAction)
+
+This StepAction runs `go vet` to report likely mistakes in Go source code. It
+is a StepAction-only tool, designed to be composed with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-vet-alpine/golang-vet-alpine.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `packages` | Packages to vet | `./...` |
+| `flags` | Additional flags to pass to `go vet` | `""` |
+| `version` | Golang version to use | `1.26` |
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: vet-check
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: vet
+        ref:
+          name: golang-vet-alpine
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+```

--- a/stepaction/golang-vet-alpine/golang-vet-alpine.yaml
+++ b/stepaction/golang-vet-alpine/golang-vet-alpine.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang vet (alpine)
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
   labels:

--- a/stepaction/golang-vet-alpine/golang-vet-alpine.yaml
+++ b/stepaction/golang-vet-alpine/golang-vet-alpine.yaml
@@ -42,5 +42,10 @@ spec:
       default: "1.26"
   image: docker.io/library/golang:$(params.version)-alpine
   workingDir: $(params.source-path)
+  env:
+    - name: PARAM_FLAGS
+      value: $(params.flags)
+    - name: PARAM_PACKAGES
+      value: $(params.packages)
   script: |
-    go vet $(params.flags) $(params.packages)
+    go vet ${PARAM_FLAGS} ${PARAM_PACKAGES}

--- a/stepaction/golang-vet-alpine/golang-vet-alpine.yaml
+++ b/stepaction/golang-vet-alpine/golang-vet-alpine.yaml
@@ -1,0 +1,46 @@
+# Generated from base/golang-vet.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-vet-alpine
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Code Quality
+    tekton.dev/displayName: golang vet (alpine)
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: lint
+  labels:
+    app.kubernetes.io/version: 1.2.0
+spec:
+  description: This StepAction runs 'go vet' to report likely mistakes in Go source code. Uses the Alpine-based Go image for smaller footprint.
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: packages
+      description: packages to vet
+      default: ./...
+    - name: flags
+      description: additional flags to pass to 'go vet'
+      default: ""
+    - name: version
+      description: golang version to use
+      default: "1.26"
+  image: docker.io/library/golang:$(params.version)-alpine
+  workingDir: $(params.source-path)
+  script: |
+    go vet $(params.flags) $(params.packages)

--- a/stepaction/golang-vet/README.md
+++ b/stepaction/golang-vet/README.md
@@ -1,0 +1,49 @@
+# Golang Vet (StepAction)
+
+This StepAction runs `go vet` to report likely mistakes in Go source code. It
+is a StepAction-only tool, designed to be composed with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/golang-vet/golang-vet.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `packages` | Packages to vet | `./...` |
+| `flags` | Additional flags to pass to `go vet` | `""` |
+| `version` | Golang version to use | `1.26` |
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: vet-check
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: vet
+        ref:
+          name: golang-vet
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+```

--- a/stepaction/golang-vet/golang-vet.yaml
+++ b/stepaction/golang-vet/golang-vet.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Code Quality
     tekton.dev/displayName: golang vet
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: lint
   labels:

--- a/stepaction/golang-vet/golang-vet.yaml
+++ b/stepaction/golang-vet/golang-vet.yaml
@@ -1,0 +1,46 @@
+# Generated from base/golang-vet.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: golang-vet
+  annotations:
+    artifacthub.io/category: integration-delivery
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Code Quality
+    tekton.dev/displayName: golang vet
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: lint
+  labels:
+    app.kubernetes.io/version: 1.2.0
+spec:
+  description: This StepAction runs 'go vet' to report likely mistakes in Go source code.
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: packages
+      description: packages to vet
+      default: ./...
+    - name: flags
+      description: additional flags to pass to 'go vet'
+      default: ""
+    - name: version
+      description: golang version to use
+      default: "1.26"
+  image: docker.io/library/golang:$(params.version)
+  workingDir: $(params.source-path)
+  script: |
+    go vet $(params.flags) $(params.packages)

--- a/stepaction/golang-vet/golang-vet.yaml
+++ b/stepaction/golang-vet/golang-vet.yaml
@@ -42,5 +42,10 @@ spec:
       default: "1.26"
   image: docker.io/library/golang:$(params.version)
   workingDir: $(params.source-path)
+  env:
+    - name: PARAM_FLAGS
+      value: $(params.flags)
+    - name: PARAM_PACKAGES
+      value: $(params.packages)
   script: |
-    go vet $(params.flags) $(params.packages)
+    go vet ${PARAM_FLAGS} ${PARAM_PACKAGES}

--- a/stepaction/govulncheck-alpine/README.md
+++ b/stepaction/govulncheck-alpine/README.md
@@ -1,0 +1,53 @@
+# Govulncheck (StepAction)
+
+This StepAction scans Go code for known vulnerabilities using
+[govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck). It is a
+StepAction-only tool, designed to be composed with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/govulncheck-alpine/govulncheck-alpine.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `packages` | Packages to scan | `./...` |
+| `govulncheck-version` | Version of govulncheck to install | `latest` |
+| `version` | Golang version to use | `1.26` |
+
+> Installs `govulncheck` at runtime via `go install`, so the step needs network
+> access to the Go module proxy and the vulnerability database.
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: vuln-scan
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: govulncheck-alpine
+        ref:
+          name: govulncheck-alpine
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+```

--- a/stepaction/govulncheck-alpine/govulncheck-alpine.yaml
+++ b/stepaction/govulncheck-alpine/govulncheck-alpine.yaml
@@ -45,7 +45,11 @@ spec:
   env:
     - name: GOBIN
       value: /tekton/home/go/bin
+    - name: PARAM_GOVULNCHECK_VERSION
+      value: $(params.govulncheck-version)
+    - name: PARAM_PACKAGES
+      value: $(params.packages)
   script: |
     export PATH="${GOBIN}:${PATH}"
-    go install golang.org/x/vuln/cmd/govulncheck@$(params.govulncheck-version)
-    govulncheck $(params.packages)
+    go install golang.org/x/vuln/cmd/govulncheck@${PARAM_GOVULNCHECK_VERSION}
+    govulncheck ${PARAM_PACKAGES}

--- a/stepaction/govulncheck-alpine/govulncheck-alpine.yaml
+++ b/stepaction/govulncheck-alpine/govulncheck-alpine.yaml
@@ -1,0 +1,51 @@
+# Generated from base/govulncheck.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: govulncheck-alpine
+  annotations:
+    artifacthub.io/category: security
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Security
+    tekton.dev/displayName: govulncheck (alpine)
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: security
+  labels:
+    app.kubernetes.io/version: 1.2.0
+spec:
+  description: This StepAction scans Go code for known vulnerabilities using govulncheck. Uses the Alpine-based Go image for smaller footprint.
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: packages
+      description: packages to scan
+      default: ./...
+    - name: govulncheck-version
+      description: version of govulncheck to install
+      default: latest
+    - name: version
+      description: golang version to use
+      default: "1.26"
+  image: docker.io/library/golang:$(params.version)-alpine
+  workingDir: $(params.source-path)
+  env:
+    - name: GOBIN
+      value: /tekton/home/go/bin
+  script: |
+    export PATH="${GOBIN}:${PATH}"
+    go install golang.org/x/vuln/cmd/govulncheck@$(params.govulncheck-version)
+    govulncheck $(params.packages)

--- a/stepaction/govulncheck-alpine/govulncheck-alpine.yaml
+++ b/stepaction/govulncheck-alpine/govulncheck-alpine.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Security
     tekton.dev/displayName: govulncheck (alpine)
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: security
   labels:

--- a/stepaction/govulncheck/README.md
+++ b/stepaction/govulncheck/README.md
@@ -1,0 +1,53 @@
+# Govulncheck (StepAction)
+
+This StepAction scans Go code for known vulnerabilities using
+[govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck). It is a
+StepAction-only tool, designed to be composed with other steps.
+
+## Installation
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd-catalog/golang/main/stepaction/govulncheck/govulncheck.yaml
+```
+
+> Requires Tekton Pipelines with StepActions enabled (`enable-step-actions: "true"`).
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `source-path` | Path to the Go source code to operate on | _(required)_ |
+| `packages` | Packages to scan | `./...` |
+| `govulncheck-version` | Version of govulncheck to install | `latest` |
+| `version` | Golang version to use | `1.26` |
+
+> Installs `govulncheck` at runtime via `go install`, so the step needs network
+> access to the Go module proxy and the vulnerability database.
+
+## Platforms
+
+The StepAction can be run on `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: vuln-scan
+spec:
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+      - name: govulncheck
+        ref:
+          name: govulncheck
+        params:
+          - name: source-path
+            value: $(workspaces.source.path)
+```

--- a/stepaction/govulncheck/govulncheck.yaml
+++ b/stepaction/govulncheck/govulncheck.yaml
@@ -45,7 +45,11 @@ spec:
   env:
     - name: GOBIN
       value: /tekton/home/go/bin
+    - name: PARAM_GOVULNCHECK_VERSION
+      value: $(params.govulncheck-version)
+    - name: PARAM_PACKAGES
+      value: $(params.packages)
   script: |
     export PATH="${GOBIN}:${PATH}"
-    go install golang.org/x/vuln/cmd/govulncheck@$(params.govulncheck-version)
-    govulncheck $(params.packages)
+    go install golang.org/x/vuln/cmd/govulncheck@${PARAM_GOVULNCHECK_VERSION}
+    govulncheck ${PARAM_PACKAGES}

--- a/stepaction/govulncheck/govulncheck.yaml
+++ b/stepaction/govulncheck/govulncheck.yaml
@@ -1,0 +1,51 @@
+# Generated from base/govulncheck.yaml — do not edit directly.
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: govulncheck
+  annotations:
+    artifacthub.io/category: security
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: support
+        url: https://github.com/tektoncd-catalog/golang/issues
+    artifacthub.io/maintainers: |
+      - name: Vincent Demeester
+        email: vincent@sbr.pm
+      - name: vinamra28
+        email: jvinamra776@gmail.com
+    artifacthub.io/provider: Tekton
+    tekton.dev/catalog: tektoncd.golang
+    tekton.dev/catalog-support-tier: verified
+    tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
+    tekton.dev/categories: Security
+    tekton.dev/displayName: govulncheck
+    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: security
+  labels:
+    app.kubernetes.io/version: 1.2.0
+spec:
+  description: This StepAction scans Go code for known vulnerabilities using govulncheck.
+  params:
+    - name: source-path
+      description: Path to the Go source code to operate on.
+      type: string
+    - name: packages
+      description: packages to scan
+      default: ./...
+    - name: govulncheck-version
+      description: version of govulncheck to install
+      default: latest
+    - name: version
+      description: golang version to use
+      default: "1.26"
+  image: docker.io/library/golang:$(params.version)
+  workingDir: $(params.source-path)
+  env:
+    - name: GOBIN
+      value: /tekton/home/go/bin
+  script: |
+    export PATH="${GOBIN}:${PATH}"
+    go install golang.org/x/vuln/cmd/govulncheck@$(params.govulncheck-version)
+    govulncheck $(params.packages)

--- a/stepaction/govulncheck/govulncheck.yaml
+++ b/stepaction/govulncheck/govulncheck.yaml
@@ -20,7 +20,7 @@ metadata:
     tekton.dev/catalog-url: https://github.com/tektoncd-catalog/golang
     tekton.dev/categories: Security
     tekton.dev/displayName: govulncheck
-    tekton.dev/pipelines.minVersion: 0.40.0
+    tekton.dev/pipelines.minVersion: "1.0.0"
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: security
   labels:

--- a/task/golang-build-alpine/golang-build-alpine.yaml
+++ b/task/golang-build-alpine/golang-build-alpine.yaml
@@ -37,7 +37,7 @@ spec:
       description: golang version to use for builds
       default: "1.26"
     - name: flags
-      description: flags to use for the test command
+      description: flags to use for the build command
       default: -v
     - name: GOOS
       description: running program's operating system target

--- a/task/golang-build-alpine/golang-build-alpine.yaml
+++ b/task/golang-build-alpine/golang-build-alpine.yaml
@@ -81,11 +81,17 @@ spec:
           value: $(params.CGO_ENABLED)
         - name: GOSUMDB
           value: $(params.GOSUMDB)
+        - name: PACKAGE
+          value: $(params.package)
+        - name: PACKAGES
+          value: $(params.packages)
+        - name: FLAGS
+          value: $(params.flags)
       script: |
-        if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-          SRC_PATH="$GOPATH/src/$(params.package)"
+        if [ ! -e $GOPATH/src/${PACKAGE}/go.mod ];then
+          SRC_PATH="$GOPATH/src/${PACKAGE}"
           mkdir -p $SRC_PATH
           cp -R "$(workspaces.source.path)"/* $SRC_PATH
           cd $SRC_PATH
         fi
-        go build $(params.flags) $(params.packages)
+        go build ${FLAGS} ${PACKAGES}

--- a/task/golang-build/golang-build.yaml
+++ b/task/golang-build/golang-build.yaml
@@ -37,7 +37,7 @@ spec:
       description: golang version to use for builds
       default: "1.26"
     - name: flags
-      description: flags to use for the test command
+      description: flags to use for the build command
       default: -v
     - name: GOOS
       description: running program's operating system target

--- a/task/golang-build/golang-build.yaml
+++ b/task/golang-build/golang-build.yaml
@@ -81,11 +81,17 @@ spec:
           value: $(params.CGO_ENABLED)
         - name: GOSUMDB
           value: $(params.GOSUMDB)
+        - name: PACKAGE
+          value: $(params.package)
+        - name: PACKAGES
+          value: $(params.packages)
+        - name: FLAGS
+          value: $(params.flags)
       script: |
-        if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-          SRC_PATH="$GOPATH/src/$(params.package)"
+        if [ ! -e $GOPATH/src/${PACKAGE}/go.mod ];then
+          SRC_PATH="$GOPATH/src/${PACKAGE}"
           mkdir -p $SRC_PATH
           cp -R "$(workspaces.source.path)"/* $SRC_PATH
           cd $SRC_PATH
         fi
-        go build $(params.flags) $(params.packages)
+        go build ${FLAGS} ${PACKAGES}

--- a/task/golang-test-alpine/golang-test-alpine.yaml
+++ b/task/golang-test-alpine/golang-test-alpine.yaml
@@ -74,11 +74,19 @@ spec:
           value: $(params.GOCACHE)
         - name: GOMODCACHE
           value: $(params.GOMODCACHE)
+        - name: PACKAGE
+          value: $(params.package)
+        - name: PACKAGES
+          value: $(params.packages)
+        - name: FLAGS
+          value: $(params.flags)
+        - name: CONTEXT
+          value: $(params.context)
       script: |
-        if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-           SRC_PATH="$GOPATH/src/$(params.package)"
+        if [ ! -e $GOPATH/src/${PACKAGE}/go.mod ];then
+           SRC_PATH="$GOPATH/src/${PACKAGE}"
            mkdir -p $SRC_PATH
-           cp -R "$(workspaces.source.path)/$(params.context)"/* $SRC_PATH
+           cp -R "$(workspaces.source.path)/${CONTEXT}"/* $SRC_PATH
            cd $SRC_PATH
         fi
-        go test $(params.flags) $(params.packages)
+        go test ${FLAGS} ${PACKAGES}

--- a/task/golang-test/golang-test.yaml
+++ b/task/golang-test/golang-test.yaml
@@ -74,11 +74,19 @@ spec:
           value: $(params.GOCACHE)
         - name: GOMODCACHE
           value: $(params.GOMODCACHE)
+        - name: PACKAGE
+          value: $(params.package)
+        - name: PACKAGES
+          value: $(params.packages)
+        - name: FLAGS
+          value: $(params.flags)
+        - name: CONTEXT
+          value: $(params.context)
       script: |
-        if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
-           SRC_PATH="$GOPATH/src/$(params.package)"
+        if [ ! -e $GOPATH/src/${PACKAGE}/go.mod ];then
+           SRC_PATH="$GOPATH/src/${PACKAGE}"
            mkdir -p $SRC_PATH
-           cp -R "$(workspaces.source.path)/$(params.context)"/* $SRC_PATH
+           cp -R "$(workspaces.source.path)/${CONTEXT}"/* $SRC_PATH
            cd $SRC_PATH
         fi
-        go test $(params.flags) $(params.packages)
+        go test ${FLAGS} ${PACKAGES}

--- a/test/e2e-stepactions.sh
+++ b/test/e2e-stepactions.sh
@@ -55,10 +55,8 @@ for sadir in "${ROOT_DIR}"/stepaction/*/; do
 done
 
 echo "--- Applying StepAction composition test"
-# Use 'create' for the PipelineRun (uses generateName for idempotency),
-# but 'apply' for the Pipeline definition.
-kubectl apply -f <(yq 'select(.kind == "Pipeline")' "${ROOT_DIR}/test/stepactions/composition.yaml")
-kubectl create -f <(yq 'select(.kind == "PipelineRun")' "${ROOT_DIR}/test/stepactions/composition.yaml")
+kubectl apply -f "${ROOT_DIR}/test/stepactions/pipeline.yaml"
+kubectl create -f "${ROOT_DIR}/test/stepactions/pipelinerun.yaml"
 
 sleep 5
 

--- a/test/e2e-stepactions.sh
+++ b/test/e2e-stepactions.sh
@@ -55,7 +55,10 @@ for sadir in "${ROOT_DIR}"/stepaction/*/; do
 done
 
 echo "--- Applying StepAction composition test"
-kubectl apply -f "${ROOT_DIR}/test/stepactions/composition.yaml"
+# Use 'create' for the PipelineRun (uses generateName for idempotency),
+# but 'apply' for the Pipeline definition.
+kubectl apply -f <(yq 'select(.kind == "Pipeline")' "${ROOT_DIR}/test/stepactions/composition.yaml")
+kubectl create -f <(yq 'select(.kind == "PipelineRun")' "${ROOT_DIR}/test/stepactions/composition.yaml")
 
 sleep 5
 

--- a/test/e2e-stepactions.sh
+++ b/test/e2e-stepactions.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# E2e test runner for the golang StepActions.
+# Installs the default (Debian) StepActions and runs a composition Pipeline
+# that uses golang-fmt, golang-vet, golang-build and golang-test as steps in
+# a single Task — exercising the composable StepAction workflow.
+#
+# Environment variables:
+#   PIPELINE_VERSION  - Tekton Pipelines version to install (default: v1.12.0)
+#   TIMEOUT           - Timeout for the PipelineRun (default: 300s)
+
+set -euo pipefail
+
+PIPELINE_VERSION="${PIPELINE_VERSION:-v1.12.0}"
+TIMEOUT="${TIMEOUT:-300s}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "--- Installing Tekton Pipelines ${PIPELINE_VERSION}"
+kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/${PIPELINE_VERSION}/release.yaml"
+echo "--- Waiting for Tekton Pipelines to be ready"
+kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-controller -n tekton-pipelines
+kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-webhook -n tekton-pipelines
+
+echo "--- Enabling StepActions (enable-step-actions)"
+kubectl patch configmap feature-flags -n tekton-pipelines \
+    --type merge -p '{"data":{"enable-step-actions":"true"}}'
+
+echo "--- Installing git-clone task"
+kubectl apply -f "https://raw.githubusercontent.com/tektoncd-catalog/git-clone/v1.6.0/task/git-clone/git-clone.yaml"
+
+echo "--- Installing golang StepActions (default/Debian variants)"
+for sadir in "${ROOT_DIR}"/stepaction/*/; do
+    name="$(basename "${sadir}")"
+    # Only the default (non-alpine) variants for the smoke test.
+    [[ "${name}" == *-alpine ]] && continue
+    f="${sadir}${name}.yaml"
+    [[ -f "${f}" ]] || continue
+    echo "    Applying ${f}"
+    kubectl apply -f "${f}"
+done
+
+echo "--- Applying StepAction composition test"
+kubectl apply -f "${ROOT_DIR}/test/stepactions/composition.yaml"
+
+sleep 5
+
+PIPELINERUNS=$(kubectl get pipelinerun -o name | sed 's|pipelinerun.tekton.dev/||')
+
+FAILED=0
+PASSED=0
+TOTAL=0
+
+echo "--- Waiting for PipelineRuns to complete (timeout: ${TIMEOUT})"
+for pr in ${PIPELINERUNS}; do
+    TOTAL=$((TOTAL + 1))
+    echo -n "  ${pr} ... "
+    if kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" pipelinerun/"${pr}" 2>/dev/null; then
+        echo "PASSED"
+        PASSED=$((PASSED + 1))
+    else
+        echo "FAILED"
+        kubectl get pipelinerun/"${pr}" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
+        echo ""
+        kubectl get taskrun -l tekton.dev/pipelineRun="${pr}" \
+            -o custom-columns='NAME:.metadata.name,STATUS:.status.conditions[0].reason,MESSAGE:.status.conditions[0].message' 2>/dev/null || true
+        for pod in $(kubectl get pods -l tekton.dev/pipelineRun="${pr}" -o name 2>/dev/null); do
+            echo "  >> ${pod}"
+            kubectl logs "${pod}" --all-containers 2>/dev/null || true
+        done
+        FAILED=$((FAILED + 1))
+    fi
+done
+
+echo ""
+echo "=== Results: ${PASSED}/${TOTAL} passed, ${FAILED} failed ==="
+
+if [[ ${FAILED} -gt 0 ]]; then
+    exit 1
+fi

--- a/test/stepactions/composition.yaml
+++ b/test/stepactions/composition.yaml
@@ -75,7 +75,7 @@ spec:
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  name: golang-stepactions-run-uuid
+  generateName: golang-stepactions-run-
 spec:
   pipelineRef:
     name: golang-stepactions-pipeline

--- a/test/stepactions/composition.yaml
+++ b/test/stepactions/composition.yaml
@@ -37,12 +37,6 @@ spec:
         workspaces:
           - name: source
         steps:
-          - name: fmt
-            ref:
-              name: golang-fmt
-            params:
-              - name: source-path
-                value: $(workspaces.source.path)
           - name: vet
             ref:
               name: golang-vet

--- a/test/stepactions/composition.yaml
+++ b/test/stepactions/composition.yaml
@@ -37,6 +37,12 @@ spec:
         workspaces:
           - name: source
         steps:
+          - name: fmt
+            ref:
+              name: golang-fmt
+            params:
+              - name: source-path
+                value: $(workspaces.source.path)
           - name: vet
             ref:
               name: golang-vet
@@ -75,9 +81,9 @@ spec:
     name: golang-stepactions-pipeline
   params:
     - name: url
-      value: https://github.com/google/uuid
+      value: https://github.com/stretchr/testify
     - name: package
-      value: github.com/google/uuid
+      value: github.com/stretchr/testify
     - name: packages
       value: "./..."
   workspaces:

--- a/test/stepactions/composition.yaml
+++ b/test/stepactions/composition.yaml
@@ -43,6 +43,12 @@ spec:
             params:
               - name: source-path
                 value: $(workspaces.source.path)
+          - name: goimports
+            ref:
+              name: golang-goimports
+            params:
+              - name: source-path
+                value: $(workspaces.source.path)
           - name: vet
             ref:
               name: golang-vet

--- a/test/stepactions/composition.yaml
+++ b/test/stepactions/composition.yaml
@@ -1,0 +1,97 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: golang-stepactions-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  params:
+    - name: url
+      description: Repository URL to clone from
+    - name: package
+      description: base package
+    - name: packages
+      description: packages to build/test
+      default: "./..."
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.url)
+        - name: deleteExisting
+          value: "true"
+    # A single Task composed entirely of StepActions, demonstrating the
+    # composable workflow: fmt + vet + build + test as steps.
+    - name: go-checks
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      taskSpec:
+        workspaces:
+          - name: source
+        steps:
+          - name: fmt
+            ref:
+              name: golang-fmt
+            params:
+              - name: source-path
+                value: $(workspaces.source.path)
+          - name: vet
+            ref:
+              name: golang-vet
+            params:
+              - name: source-path
+                value: $(workspaces.source.path)
+              - name: packages
+                value: $(params.packages)
+          - name: build
+            ref:
+              name: golang-build
+            params:
+              - name: source-path
+                value: $(workspaces.source.path)
+              - name: package
+                value: $(params.package)
+              - name: packages
+                value: $(params.packages)
+          - name: test
+            ref:
+              name: golang-test
+            params:
+              - name: source-path
+                value: $(workspaces.source.path)
+              - name: package
+                value: $(params.package)
+              - name: packages
+                value: $(params.packages)
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: golang-stepactions-run-uuid
+spec:
+  pipelineRef:
+    name: golang-stepactions-pipeline
+  params:
+    - name: url
+      value: https://github.com/google/uuid
+    - name: package
+      value: github.com/google/uuid
+    - name: packages
+      value: "./..."
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 256Mi

--- a/test/stepactions/pipeline.yaml
+++ b/test/stepactions/pipeline.yaml
@@ -8,6 +8,9 @@ spec:
   params:
     - name: url
       description: Repository URL to clone from
+    - name: revision
+      description: Git revision to checkout
+      default: main
     - name: package
       description: base package
     - name: packages
@@ -23,6 +26,8 @@ spec:
       params:
         - name: url
           value: $(params.url)
+        - name: revision
+          value: $(params.revision)
         - name: deleteExisting
           value: "true"
     # A single Task composed entirely of StepActions, demonstrating the
@@ -77,27 +82,3 @@ spec:
                 value: $(params.package)
               - name: packages
                 value: $(params.packages)
----
-apiVersion: tekton.dev/v1
-kind: PipelineRun
-metadata:
-  generateName: golang-stepactions-run-
-spec:
-  pipelineRef:
-    name: golang-stepactions-pipeline
-  params:
-    - name: url
-      value: https://github.com/stretchr/testify
-    - name: package
-      value: github.com/stretchr/testify
-    - name: packages
-      value: "./..."
-  workspaces:
-    - name: shared-workspace
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 256Mi

--- a/test/stepactions/pipelinerun.yaml
+++ b/test/stepactions/pipelinerun.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: golang-stepactions-run-
+spec:
+  pipelineRef:
+    name: golang-stepactions-pipeline
+  params:
+    - name: url
+      value: https://github.com/sirupsen/logrus
+    - name: revision
+      value: d4a50659cfd64d348122edc79ee342dbb526e5de
+    - name: package
+      value: github.com/sirupsen/logrus
+    - name: packages
+      value: "./..."
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 256Mi

--- a/variants.yaml
+++ b/variants.yaml
@@ -1,7 +1,0 @@
-variants:
-  - suffix: ""
-    image: "docker.io/library/golang:$(params.version)"
-    description_suffix: ""
-  - suffix: "-alpine"
-    image: "docker.io/library/golang:$(params.version)-alpine"
-    description_suffix: " Uses the Alpine-based Go image for smaller footprint."


### PR DESCRIPTION
Closes #27. Builds on #29 (deterministic generation + VERSION source of truth).

## Summary

Adds StepActions to the catalog, a central catalog manifest, and new StepAction-only Go tools. Three generation modes: Task+StepAction (derived), StepAction-only (direct), and Task-only (existing).

## Catalog structure (Option D)

New `catalog.yaml` replaces `variants.yaml` as the single source of truth — lists each tool and the kinds to generate, plus variants. Downstream forks one file.

```yaml
tools:
  - { name: golang-build,     generate: [task, stepaction] }
  - { name: golang-test,      generate: [task, stepaction] }
  - { name: golang-fmt,       generate: [stepaction] }
  - { name: golang-goimports, generate: [stepaction] }
  - { name: golang-vet,       generate: [stepaction] }
  - { name: golang-fix,       generate: [stepaction] }
  - { name: govulncheck,      generate: [stepaction] }
variants: [ "", -alpine ]
```

## Tools

| Tool | Task | StepAction | Notes |
|------|------|-----------|-------|
| `golang-build` | ✅ | ✅ derived | |
| `golang-test` | ✅ | ✅ derived | |
| `golang-fmt` | ❌ | ✅ | `gofmt -l`, with `skip-dirs` (default: `vendor`) |
| `golang-goimports` | ❌ | ✅ | **New** — superset of gofmt (formatting + import ordering) |
| `golang-vet` | ❌ | ✅ | `go vet ./...` |
| `golang-fix` | ❌ | ✅ | `go fix ./...` (Go 1.26+) |
| `govulncheck` | ❌ | ✅ | installs + runs govulncheck |

Every StepAction gets Debian + Alpine variants (**14 StepActions** total).

## Generation

- **`generate.sh`** driven by `catalog.yaml`. For Task bases it renders the Task variant and derives a StepAction; for StepAction bases it renders the StepAction directly.
- **`generate-stepaction.py`** — golang-specific derivation (simplified port of git-clone's): maps the single `source` workspace to a `source-path` param, rewrites `$(workspaces.source.path)` to `${SOURCE_PATH}` env var in scripts. Uses `uv run --with pyyaml`.
- All `$(params.*)` references moved out of `script:` blocks into env vars — both in Tasks and StepActions. Tekton Pipelines v1.12.0+ forbids param substitution in StepAction scripts, and using env vars is safer for Tasks too.

## CI / release

- **Lint**: `verify-generated` covers `task/` + `stepaction/`, ignores `tekton.dev/signature` and `artifacthub.io/changes` (release-time annotations). Validation step checks StepActions (`kind: StepAction`, `tekton.dev/v1beta1`).
- **E2E**: new `e2e-stepactions` job runs a composition Pipeline: `fmt → vet → build → test` as StepActions in a single Task against `stretchr/testify` (passes all four checks).
- **Release**: `release.yaml` publishes + cosign-signs `stepaction-<name>` bundles. `release.sh` commits `stepaction/` alongside `task/`, injects `artifacthub.io/changes` into all generated YAMLs.
- **Docs**: README per StepAction + alpine variants. Main README has a StepActions section with composition example. Artifact Hub metadata for StepActions repo (ID: `82f59bf4-b291-41d0-960b-d52bbafa713c`).

## Key design decisions

- **Env vars over `$(params.*)` in scripts**: Pipelines v1.12.0 blocks param substitution in StepAction `spec.script`. Applied to Tasks too for consistency — `$(params.*)` now only appears in `env[].value`, `image`, and `workingDir`.
- **`skip-dirs` for fmt/goimports**: Default excludes `vendor/`. Pipe-separated regex via `find | grep -Ev`.
- **`golang-goimports` as separate tool**: Superset of gofmt (formatting + imports). Different from `golang-fmt` — projects choose one or the other.

```release-note
Added StepActions for golang-build and golang-test (derived from Tasks), plus StepAction-only Go tools: golang-fmt (with vendor skip), golang-goimports, golang-vet, golang-fix, and govulncheck. All available in Debian and Alpine variants. Introduced catalog.yaml as the central catalog manifest.
```