### PR TITLE
docs: add DEVELOPMENT.md, CONTRIBUTING.md, and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in `tektoncd-catalog/golang`. For full
+detail see [DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Repository structure
+
+| Path | Role |
+|------|------|
+| `base/*.yaml` | **Edit these.** Hand-maintained templates (one per tool), version-agnostic, with `IMAGE_PLACEHOLDER`. |
+| `catalog.yaml` | Manifest: which tools to generate, which kinds (`task`/`stepaction`), and the variants. Single source of truth for *what* is produced. |
+| `VERSION` | Single source of truth for the version (injected as `app.kubernetes.io/version`). |
+| `hack/generate.sh` | Generator: `base/` + `catalog.yaml` + `VERSION` → `task/` + `stepaction/`. |
+| `hack/generate-stepaction.py` | Derives a StepAction from a generated Task. |
+| `hack/release.sh` | Release automation. |
+| `task/`, `stepaction/` | **Generated — never edit by hand.** |
+| `test/` | e2e runners (`e2e-tests.sh`, `e2e-tests-alpine.sh`, `e2e-stepactions.sh`, `e2e-bundle-test.sh`). |
+| `.github/workflows/` | `build.yaml` (lint/verify/e2e), `release.yaml` (bundle publish). |
+
+## Critical invariants
+
+- **Never edit `task/` or `stepaction/` directly.** Edit `base/` and/or
+  `catalog.yaml`, then run `./hack/generate.sh`. CI's verify-generated step
+  diffs committed files against freshly generated ones and fails on mismatch.
+- **Templates are version-agnostic.** The version lives only in `VERSION`.
+- **`$(params.*)` is NOT allowed in StepAction `script:` blocks.** Pass values
+  via `env:` and reference the env var (e.g. `${SOURCE_PATH}`, `${PARAM_PATHS}`).
+  Workspace refs in scripts become `${SOURCE_PATH}`; in `workingDir`/`env`
+  values they become `$(params.source-path)`.
+- **Commits must be signed off** (DCO): `git commit --signoff`.
+- **Use conventional commit prefixes** (`feat:`, `fix:`, `docs:`, `chore:`,
+  `ci:`) — the changelog is derived from them.
+
+## Common commands
+
+```bash
+./hack/generate.sh                      # regenerate task/ + stepaction/
+./hack/generate.sh my-catalog.yaml      # regenerate from a forked manifest
+./hack/release.sh v1.3.0 --dry-run      # preview a release (restores the tree)
+./hack/release.sh v1.3.0 --dry-run --llm# preview with gh copilot changelog
+./test/e2e-tests.sh                     # e2e in a kind cluster (needs a cluster)
+```
+
+Generation needs `yq` (mikefarah) and either `uv` or a `python3` with PyYAML.
+
+## Validating changes locally
+
+1. After editing `base/`/`catalog.yaml`, run `./hack/generate.sh`.
+2. Confirm `git status` shows only intended changes (clean verify-generated).
+3. Run the relevant e2e script against a kind cluster.
+4. Update `README.md` if you added a tool or variant.
+
+## Common pitfalls
+
+- Forgetting to run `./hack/generate.sh` after editing a template → CI
+  verify-generated fails.
+- Putting `$(params.*)` in a StepAction script → invalid; use env vars.
+- Adding a version to a `base/` template → breaks determinism; versions come
+  from `VERSION`.
+- Editing a generated `README.md` for an `-alpine` variant → it's regenerated
+  from the default tool's README; edit the default instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,11 +23,12 @@ detail see [DEVELOPMENT.md](DEVELOPMENT.md).
    `base/` and/or `catalog.yaml`, then run `./hack/generate.sh`. CI's
    verify-generated step diffs committed files against freshly generated ones
    and fails on mismatch.
-2. **No `$(params.*)` in StepAction `script:` blocks** — injection risk and not
-   supported. Pass values via `env:` and reference the env var (e.g.
+2. **No `$(params.*)` in `script:` blocks** (Tasks *and* StepActions) —
+   injection risk. Pass values via `env:` and reference the env var (e.g.
    `${SOURCE_PATH}`, `${PARAM_PATHS}`). Workspace refs in scripts become
    `${SOURCE_PATH}`; in `workingDir`/`env` values they become
-   `$(params.source-path)`.
+   `$(params.source-path)`. (For StepActions `$(params.*)` in scripts is also
+   not supported at all.)
 3. **Templates are version-agnostic.** The version lives only in the `VERSION`
    file and is injected as the `app.kubernetes.io/version` label at generation
    time. Never hardcode a version in `base/`.
@@ -58,7 +59,7 @@ Generation needs `yq` (mikefarah) and either `uv` or a `python3` with PyYAML.
 
 - Forgetting to run `./hack/generate.sh` after editing a template → CI
   verify-generated fails.
-- Putting `$(params.*)` in a StepAction script → invalid; use env vars.
+- Putting `$(params.*)` in a `script:` block (Task or StepAction) → use env vars.
 - Adding a version to a `base/` template → breaks determinism; versions come
   from `VERSION`.
 - Editing a generated `README.md` for an `-alpine` variant → it's regenerated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,27 +17,31 @@ detail see [DEVELOPMENT.md](DEVELOPMENT.md).
 | `test/` | e2e runners (`e2e-tests.sh`, `e2e-tests-alpine.sh`, `e2e-stepactions.sh`, `e2e-bundle-test.sh`). |
 | `.github/workflows/` | `build.yaml` (lint/verify/e2e), `release.yaml` (bundle publish). |
 
-## Critical invariants
+## Critical Rules
 
-- **Never edit `task/` or `stepaction/` directly.** Edit `base/` and/or
-  `catalog.yaml`, then run `./hack/generate.sh`. CI's verify-generated step
-  diffs committed files against freshly generated ones and fails on mismatch.
-- **Templates are version-agnostic.** The version lives only in `VERSION`.
-- **`$(params.*)` is NOT allowed in StepAction `script:` blocks.** Pass values
-  via `env:` and reference the env var (e.g. `${SOURCE_PATH}`, `${PARAM_PATHS}`).
-  Workspace refs in scripts become `${SOURCE_PATH}`; in `workingDir`/`env`
-  values they become `$(params.source-path)`.
-- **Commits must be signed off** (DCO): `git commit --signoff`.
-- **Use conventional commit prefixes** (`feat:`, `fix:`, `docs:`, `chore:`,
-  `ci:`) — the changelog is derived from them.
+1. **Never edit `task/` or `stepaction/` directly.** They are generated. Edit
+   `base/` and/or `catalog.yaml`, then run `./hack/generate.sh`. CI's
+   verify-generated step diffs committed files against freshly generated ones
+   and fails on mismatch.
+2. **No `$(params.*)` in StepAction `script:` blocks** — injection risk and not
+   supported. Pass values via `env:` and reference the env var (e.g.
+   `${SOURCE_PATH}`, `${PARAM_PATHS}`). Workspace refs in scripts become
+   `${SOURCE_PATH}`; in `workingDir`/`env` values they become
+   `$(params.source-path)`.
+3. **Templates are version-agnostic.** The version lives only in the `VERSION`
+   file and is injected as the `app.kubernetes.io/version` label at generation
+   time. Never hardcode a version in `base/`.
+4. **Sign off every commit** (DCO / EasyCLA): `git commit --signoff`.
+5. **Use conventional commit prefixes** (`feat:`, `fix:`, `docs:`, `chore:`,
+   `ci:`) — the release changelog is derived from them.
 
 ## Common commands
 
 ```bash
 ./hack/generate.sh                      # regenerate task/ + stepaction/
 ./hack/generate.sh my-catalog.yaml      # regenerate from a forked manifest
-./hack/release.sh v1.3.0 --dry-run      # preview a release (restores the tree)
-./hack/release.sh v1.3.0 --dry-run --llm# preview with gh copilot changelog
+./hack/release.sh v1.3.0 --dry-run       # preview a release (restores the tree)
+./hack/release.sh v1.3.0 --dry-run --llm # preview with gh copilot changelog
 ./test/e2e-tests.sh                     # e2e in a kind cluster (needs a cluster)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,60 @@
-See the `tektoncd-catalog` [Contributing](https://github.com/tektoncd-catalog/.github/blob/main/CONTRIBUTING.md) doc
+# Contributing
+
+Thanks for your interest in contributing to `tektoncd-catalog/golang`! This
+repository is part of the Tekton Catalog and follows the broader
+[tektoncd-catalog contributing guide](https://github.com/tektoncd-catalog/.github/blob/main/CONTRIBUTING.md).
+
+For technical details on how the repo is structured and generated, see
+[DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Developer Certificate of Origin (DCO)
+
+All commits must be signed off to certify the
+[Developer Certificate of Origin](https://developercertificate.org/). Add a
+`Signed-off-by` trailer to every commit:
+
+```bash
+git commit --signoff -m "feat: add golang-lint StepAction"
+```
+
+The sign-off line must match the author's name and email. CI rejects PRs with
+unsigned commits.
+
+## Pull request workflow
+
+1. **Fork and branch** from `main`.
+2. **Edit `base/` templates and/or `catalog.yaml`** — never edit the generated
+   files under `task/` or `stepaction/` directly.
+3. **Regenerate** and commit the output:
+   ```bash
+   ./hack/generate.sh
+   git add base/ catalog.yaml task/ stepaction/
+   ```
+4. **Test locally** (see [DEVELOPMENT.md](DEVELOPMENT.md#running-tests-locally)).
+5. **Use conventional commit messages** (`feat:`, `fix:`, `docs:`, `chore:`,
+   `ci:`) — the release changelog is derived from these prefixes.
+6. **Open a PR** with a clear description.
+
+Approvals are managed via `OWNERS` (Prow-based auto-merge).
+
+## CI expectations
+
+Every PR runs `.github/workflows/build.yaml`, which must pass:
+
+- **Lint / verify-generated** — runs `./hack/generate.sh` and fails if the
+  committed `task/`/`stepaction/` files differ from freshly generated ones
+  (ignoring the `tekton.dev/signature` and `artifacthub.io/changes`
+  annotations). If this fails, run `./hack/generate.sh` and commit the result.
+- **Validate YAMLs** — checks `apiVersion`/`kind`/`metadata.name` for every
+  Task (`tekton.dev/v1`) and StepAction (`tekton.dev/v1beta1`).
+- **E2E matrix** — runs the e2e suites in a kind cluster across the supported
+  Tekton Pipelines LTS versions, plus Alpine and StepAction suites.
+
+> [!TIP]
+> Before pushing, run `./hack/generate.sh` and make sure `git status` is clean
+> (apart from your intended changes). This is the most common CI failure.
+
+## Code of conduct
+
+This project follows the Tekton
+[Code of Conduct](code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,18 +7,21 @@ repository is part of the Tekton Catalog and follows the broader
 For technical details on how the repo is structured and generated, see
 [DEVELOPMENT.md](DEVELOPMENT.md).
 
-## Developer Certificate of Origin (DCO)
+## Developer Certificate of Origin (DCO) / CLA
 
 All commits must be signed off to certify the
 [Developer Certificate of Origin](https://developercertificate.org/). Add a
 `Signed-off-by` trailer to every commit:
 
 ```bash
-git commit --signoff -m "feat: add golang-lint StepAction"
+git commit --signoff -m "feat: add govulncheck StepAction"
 ```
 
-The sign-off line must match the author's name and email. CI rejects PRs with
-unsigned commits.
+The sign-off line must match the author's name and email. Contributions are
+also covered by the Linux Foundation
+[EasyCLA](https://github.com/tektoncd/community/blob/main/process.md#contributor-license-agreements)
+check, which runs on pull requests — follow its prompt to sign the CLA the
+first time you contribute.
 
 ## Pull request workflow
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,1 +1,206 @@
-See [the Contributing guide](CONTRIBUTING.md).
+# Development
+
+This document explains how the `tektoncd-catalog/golang` repository is
+structured and how to develop, generate, test, and release its Tasks and
+StepActions.
+
+> [!IMPORTANT]
+> The files under `task/` and `stepaction/` are **generated**. Never edit them
+> directly. Edit the templates under `base/` (and `catalog.yaml`) and run
+> `./hack/generate.sh`.
+
+## Architecture overview
+
+The repository uses a small generation framework so that a single source of
+truth (the `base/` templates) produces every Task, StepAction, and variant.
+
+```
+base/*.yaml ──┐
+catalog.yaml ─┼─► hack/generate.sh ──► task/<name>/<name>.yaml
+VERSION ──────┘            │           stepaction/<name>/<name>.yaml
+                           └─► hack/generate-stepaction.py (Task → StepAction)
+```
+
+Key files:
+
+| Path | Role |
+|------|------|
+| `base/*.yaml` | Hand-edited template for each tool (`kind: Task` or `kind: StepAction`), version-agnostic, with `IMAGE_PLACEHOLDER` for the image. |
+| `catalog.yaml` | Manifest: the single source of truth for *what* gets generated — the list of tools, which kinds (`task`, `stepaction`) each produces, and the variants (Debian + Alpine). |
+| `VERSION` | Single source of truth for the version. Injected as the `app.kubernetes.io/version` label at generation time. |
+| `hack/generate.sh` | The generator. Renders templates per variant and injects version/image/suffixes. |
+| `hack/generate-stepaction.py` | Derives a StepAction from a generated Task (workspace → `source-path` param). |
+| `hack/release.sh` | Release automation: bump `VERSION` → regenerate → inject Artifact Hub changelog → commit → tag → push. |
+| `task/`, `stepaction/` | **Generated output.** Do not edit. |
+| `test/` | e2e test runners and fixtures. |
+
+### Why generation?
+
+- **Deterministic:** CI regenerates the files and diffs them against what's
+  committed (`verify-generated`). The committed files must match exactly.
+- **DRY:** Debian and Alpine variants share one template; a StepAction is
+  derived from its Task rather than maintained by hand.
+- **Version-agnostic templates:** `base/` never mentions a version; it's
+  injected from `VERSION`, so a version bump is just regeneration.
+
+## How generation works
+
+Run:
+
+```bash
+./hack/generate.sh                 # uses catalog.yaml
+./hack/generate.sh my-catalog.yaml # use a forked manifest
+```
+
+Requirements: [`yq`](https://github.com/mikefarah/yq) (mikefarah's Go
+implementation), and either [`uv`](https://github.com/astral-sh/uv) or a
+`python3` with PyYAML available (for StepAction derivation).
+
+For each tool in `catalog.yaml`, the generator reads `base/<name>.yaml` and,
+for each variant:
+
+1. **Renders the variant** with `render_with_variant`, which:
+   - substitutes the variant's image (replacing `IMAGE_PLACEHOLDER`),
+   - sets `metadata.name` (`<name>` or `<name>-alpine`),
+   - injects the `app.kubernetes.io/version` label from `VERSION`,
+   - appends the variant's `description_suffix` to `.spec.description`,
+   - appends a display-name suffix (e.g. ` (alpine)`).
+2. **Emits the Task** to `task/<obj_name>/<obj_name>.yaml` when `task` is in the
+   tool's `generate:` list and the base is `kind: Task`.
+3. **Derives the StepAction** when `stepaction` is requested:
+   - if the base is `kind: Task`, runs `generate-stepaction.py` on the
+     rendered Task;
+   - if the base is `kind: StepAction`, renders it directly.
+4. **Generates variant READMEs** from the default tool's README (rewriting
+   names and paths).
+
+### StepAction derivation (`generate-stepaction.py`)
+
+The golang Tasks are single-step and use a single `source` workspace, so
+deriving a StepAction is mechanical:
+
+- The `source` workspace becomes a `source-path` **param**.
+- `workingDir` and `env` value fields: `$(workspaces.source.path)` →
+  `$(params.source-path)`.
+- **Scripts:** `$(workspaces.source.path)` → `${SOURCE_PATH}`, because
+  `$(params.*)` substitution is **not allowed in StepAction scripts**. A
+  `SOURCE_PATH` env var (value `$(params.source-path)`) is injected so the
+  script can reference it.
+- Descriptions are reworded ("This Task" → "This StepAction").
+- The `tekton.dev/signature` annotation is dropped.
+
+## Adding a new tool
+
+1. Create `base/<tool>.yaml`. Use `kind: Task` if it should also be a Task, or
+   `kind: StepAction` for StepAction-only tools. Use `IMAGE_PLACEHOLDER` for
+   the image. Keep it version-agnostic (no version in labels).
+2. Add an entry to `catalog.yaml` under `tools:`:
+   ```yaml
+   - name: <tool>
+     generate: [task, stepaction]   # or just [stepaction]
+   ```
+3. Regenerate and review:
+   ```bash
+   ./hack/generate.sh
+   git status
+   ```
+4. Add e2e coverage under `test/` if applicable, and update `README.md`.
+
+### Tip: StepAction script constraints
+
+`$(params.*)` is **not** allowed inside StepAction `script:` blocks. Pass
+parameters into the script via `env:` and reference the env var instead. The
+golang StepActions follow this pattern (e.g. `PARAM_PATHS`, `SKIP_DIRS`,
+`SOURCE_PATH`).
+
+## Adding a new variant
+
+Variants apply to every tool. Add an entry to `catalog.yaml` under `variants:`:
+
+```yaml
+variants:
+  - suffix: ""                                          # default (Debian)
+    image: "docker.io/library/golang:$(params.version)"
+    description_suffix: ""
+  - suffix: "-alpine"
+    image: "docker.io/library/golang:$(params.version)-alpine"
+    description_suffix: " Uses the Alpine-based Go image for smaller footprint."
+```
+
+Then run `./hack/generate.sh` and commit the new generated artifacts.
+
+## Running tests locally
+
+E2e tests run against a real Tekton install in a local
+[kind](https://kind.sigs.k8s.io/) cluster.
+
+```bash
+# Create a cluster (or use the helm/kind-action equivalent locally)
+kind create cluster
+
+# Tasks (Debian)
+./test/e2e-tests.sh
+
+# Alpine variants
+./test/e2e-tests-alpine.sh
+
+# StepActions
+./test/e2e-stepactions.sh
+
+# Bundles
+./test/e2e-bundle-test.sh
+```
+
+Useful environment variables:
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `PIPELINE_VERSION` | `v1.12.0` | Tekton Pipelines release to install |
+| `TIMEOUT` | `300s` | Per-PipelineRun timeout |
+
+CI runs the e2e suite across the supported Tekton Pipelines LTS versions (see
+`.github/workflows/build.yaml`).
+
+## Release process
+
+Releases are driven by `hack/release.sh`:
+
+```bash
+./hack/release.sh v1.3.0 --dry-run        # preview the diff, restores the tree
+./hack/release.sh v1.3.0 --dry-run --llm  # preview with gh copilot changelog
+./hack/release.sh v1.3.0                   # bump, regenerate, commit, tag, push
+```
+
+What it does:
+
+1. Validates the version (`vX.Y.Z`) and that you're on an up-to-date `main`.
+2. Writes the bare version to `VERSION` and runs `hack/generate.sh`.
+3. Builds a changelog (from conventional-commit prefixes, or via `gh copilot`
+   with `--llm`).
+4. Injects an `artifacthub.io/changes` annotation into every generated YAML.
+5. Commits (`--signoff`), pushes `main`, creates an annotated tag, and pushes
+   the tag.
+
+The tag push triggers `.github/workflows/release.yaml`, which publishes
+cosign-signed Tekton bundles to GHCR.
+
+> [!NOTE]
+> Task YAMLs are **not** signed in-repo (tracked upstream in
+> tektoncd/cli#2894 and tektoncd/cli#2895). Bundles are cosign-signed in the
+> release workflow instead.
+
+## Downstream usage
+
+Downstream consumers can fork the manifest and point the generator at it to
+produce the same catalog with custom images:
+
+```bash
+cp catalog.yaml my-catalog.yaml
+# edit variant images to your registry
+./hack/generate.sh my-catalog.yaml
+```
+
+## See also
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contribution workflow and CI expectations.
+- [AGENTS.md](AGENTS.md) — quick reference for AI coding agents.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -106,11 +106,12 @@ deriving a StepAction is mechanical:
    ```
 4. Add e2e coverage under `test/` if applicable, and update `README.md`.
 
-### Tip: StepAction script constraints
+### Tip: script parameter constraints
 
-`$(params.*)` is **not** allowed inside StepAction `script:` blocks. Pass
+Avoid `$(params.*)` inside `script:` blocks for **both Tasks and StepActions**
+— it's an injection risk, and for StepActions it isn't supported at all. Pass
 parameters into the script via `env:` and reference the env var instead. The
-golang StepActions follow this pattern (e.g. `PARAM_PATHS`, `SKIP_DIRS`,
+golang templates follow this pattern (e.g. `PARAM_PATHS`, `SKIP_DIRS`,
 `SOURCE_PATH`).
 
 ## Adding a new variant


### PR DESCRIPTION
## Summary

Adds contributor-facing documentation for the generation framework, closing #31.

- **DEVELOPMENT.md** — architecture (`base/` + `catalog.yaml` + `VERSION` → `generate.sh` → `task/` + `stepaction/`), how to add tools/variants, generation internals (Task rendering + StepAction derivation via `generate-stepaction.py`), local e2e testing, release process (`release.sh`), and downstream usage.
- **CONTRIBUTING.md** — DCO sign-off, PR workflow, CI expectations (lint/verify-generated, validate, e2e matrix), links to DEVELOPMENT.md.
- **AGENTS.md** — repo map, critical invariants (never edit generated files, `$(params.*)` not allowed in StepAction scripts), common commands, validation steps, and pitfalls.

Follows #27. The same pattern should be applied to `tektoncd-catalog/git-clone`.

Closes #31