### PR TITLE
ci: make e2e tests more robust against flakes

### DIFF
--- a/test/e2e-bundle-test.sh
+++ b/test/e2e-bundle-test.sh
@@ -39,8 +39,19 @@ TEST_BUNDLE_REF="${BUNDLE_REGISTRY}/${BUNDLE_ID}-test:1h"
 echo "--- Installing Tekton Pipelines ${PIPELINE_VERSION}"
 kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/${PIPELINE_VERSION}/release.yaml"
 echo "--- Waiting for Tekton Pipelines to be ready"
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-controller -n tekton-pipelines
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-webhook -n tekton-pipelines
+# Wait for every control-plane deployment to be Available (cold kind nodes may
+# still be pulling images), then wait for the admission webhook to actually
+# have ready endpoints before applying any Tekton resources.
+kubectl wait --for=condition=available --timeout=300s \
+    deployment --all -n tekton-pipelines
+echo "--- Waiting for the admission webhook to serve"
+for _ in $(seq 1 30); do
+    if [[ -n "$(kubectl get endpoints tekton-pipelines-webhook \
+        -n tekton-pipelines -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null)" ]]; then
+        break
+    fi
+    sleep 5
+done
 
 echo "--- Installing git-clone task"
 kubectl apply -f "https://raw.githubusercontent.com/tektoncd-catalog/git-clone/v1.6.0/task/git-clone/git-clone.yaml"
@@ -153,20 +164,57 @@ EOF
 FAILED=0
 PASSED=0
 
+# Snapshot each PipelineRun's spec (stripped of status and volatile metadata)
+# so we can recreate it if it hits a transient flake.
+SNAP_DIR="$(mktemp -d)"
+snapshot_run() {
+    kubectl get pipelinerun/"$1" -o yaml --show-managed-fields=false 2>/dev/null \
+        | sed -e '/^status:/,$d' \
+              -e '/^  resourceVersion:/d' \
+              -e '/^  uid:/d' \
+              -e '/^  creationTimestamp:/d' \
+              -e '/^  generation:/d' \
+              -e '/^  selfLink:/d' \
+        > "${SNAP_DIR}/$1.yaml"
+}
+
+wait_for_run() {
+    kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" pipelinerun/"$1" 2>/dev/null
+}
+
+dump_run() {
+    kubectl get pipelinerun/"$1" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
+    echo ""
+    for pod in $(kubectl get pods -l tekton.dev/pipelineRun="$1" -o name 2>/dev/null); do
+        echo "  >> ${pod}"
+        kubectl logs "${pod}" --all-containers 2>/dev/null || true
+    done
+}
+
+for pr in golang-build-bundle-test golang-test-bundle-test; do
+    snapshot_run "${pr}"
+done
+
 echo "--- Waiting for PipelineRuns to complete (timeout: ${TIMEOUT})"
 for pr in golang-build-bundle-test golang-test-bundle-test; do
     echo -n "  ${pr} ... "
-    if kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" pipelinerun/"${pr}" 2>/dev/null; then
+    if wait_for_run "${pr}"; then
+        echo "PASSED"
+        PASSED=$((PASSED + 1))
+        continue
+    fi
+
+    # Retry once to absorb transient pod-startup flakes on a single-node kind
+    # cluster before declaring a real failure.
+    echo -n "FLAKY, retrying ... "
+    kubectl delete pipelinerun/"${pr}" --wait=true 2>/dev/null || true
+    kubectl apply -f "${SNAP_DIR}/${pr}.yaml" >/dev/null 2>&1 || true
+    if wait_for_run "${pr}"; then
         echo "PASSED"
         PASSED=$((PASSED + 1))
     else
         echo "FAILED"
-        kubectl get pipelinerun/"${pr}" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
-        echo ""
-        for pod in $(kubectl get pods -l tekton.dev/pipelineRun="${pr}" -o name 2>/dev/null); do
-            echo "  >> ${pod}"
-            kubectl logs "${pod}" --all-containers 2>/dev/null || true
-        done
+        dump_run "${pr}"
         FAILED=$((FAILED + 1))
     fi
 done

--- a/test/e2e-stepactions.sh
+++ b/test/e2e-stepactions.sh
@@ -33,8 +33,19 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 echo "--- Installing Tekton Pipelines ${PIPELINE_VERSION}"
 kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/${PIPELINE_VERSION}/release.yaml"
 echo "--- Waiting for Tekton Pipelines to be ready"
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-controller -n tekton-pipelines
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-webhook -n tekton-pipelines
+# Wait for every control-plane deployment to be Available (cold kind nodes may
+# still be pulling images), then wait for the admission webhook to actually
+# have ready endpoints before applying any Tekton resources.
+kubectl wait --for=condition=available --timeout=300s \
+    deployment --all -n tekton-pipelines
+echo "--- Waiting for the admission webhook to serve"
+for _ in $(seq 1 30); do
+    if [[ -n "$(kubectl get endpoints tekton-pipelines-webhook \
+        -n tekton-pipelines -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null)" ]]; then
+        break
+    fi
+    sleep 5
+done
 
 echo "--- Enabling StepActions (enable-step-actions)"
 kubectl patch configmap feature-flags -n tekton-pipelines \
@@ -66,23 +77,61 @@ FAILED=0
 PASSED=0
 TOTAL=0
 
+# Snapshot each PipelineRun's spec (stripped of status and volatile metadata)
+# so we can recreate it if it hits a transient flake. Dependency-free: kubectl
+# -o yaml orders keys with status last, so cutting from `status:` to EOF is safe.
+SNAP_DIR="$(mktemp -d)"
+snapshot_run() {
+    kubectl get pipelinerun/"$1" -o yaml --show-managed-fields=false 2>/dev/null \
+        | sed -e '/^status:/,$d' \
+              -e '/^  resourceVersion:/d' \
+              -e '/^  uid:/d' \
+              -e '/^  creationTimestamp:/d' \
+              -e '/^  generation:/d' \
+              -e '/^  selfLink:/d' \
+        > "${SNAP_DIR}/$1.yaml"
+}
+for pr in ${PIPELINERUNS}; do
+    snapshot_run "${pr}"
+done
+
+wait_for_run() {
+    kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" pipelinerun/"$1" 2>/dev/null
+}
+
+dump_run() {
+    kubectl get pipelinerun/"$1" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
+    echo ""
+    kubectl get taskrun -l tekton.dev/pipelineRun="$1" \
+        -o custom-columns='NAME:.metadata.name,STATUS:.status.conditions[0].reason,MESSAGE:.status.conditions[0].message' 2>/dev/null || true
+    for pod in $(kubectl get pods -l tekton.dev/pipelineRun="$1" -o name 2>/dev/null); do
+        echo "  >> ${pod}"
+        kubectl logs "${pod}" --all-containers 2>/dev/null || true
+    done
+}
+
 echo "--- Waiting for PipelineRuns to complete (timeout: ${TIMEOUT})"
 for pr in ${PIPELINERUNS}; do
     TOTAL=$((TOTAL + 1))
     echo -n "  ${pr} ... "
-    if kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" pipelinerun/"${pr}" 2>/dev/null; then
+    if wait_for_run "${pr}"; then
+        echo "PASSED"
+        PASSED=$((PASSED + 1))
+        continue
+    fi
+
+    # Retry once: transient pod sandbox / network / image-pull blips on a
+    # single-node kind cluster can stall a pod before its container ever runs.
+    # Recreate the PipelineRun from its snapshot and wait again before failing.
+    echo -n "FLAKY, retrying ... "
+    kubectl delete pipelinerun/"${pr}" --wait=true 2>/dev/null || true
+    kubectl apply -f "${SNAP_DIR}/${pr}.yaml" >/dev/null 2>&1 || true
+    if wait_for_run "${pr}"; then
         echo "PASSED"
         PASSED=$((PASSED + 1))
     else
         echo "FAILED"
-        kubectl get pipelinerun/"${pr}" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
-        echo ""
-        kubectl get taskrun -l tekton.dev/pipelineRun="${pr}" \
-            -o custom-columns='NAME:.metadata.name,STATUS:.status.conditions[0].reason,MESSAGE:.status.conditions[0].message' 2>/dev/null || true
-        for pod in $(kubectl get pods -l tekton.dev/pipelineRun="${pr}" -o name 2>/dev/null); do
-            echo "  >> ${pod}"
-            kubectl logs "${pod}" --all-containers 2>/dev/null || true
-        done
+        dump_run "${pr}"
         FAILED=$((FAILED + 1))
     fi
 done

--- a/test/e2e-tests-alpine.sh
+++ b/test/e2e-tests-alpine.sh
@@ -31,8 +31,19 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 echo "--- Installing Tekton Pipelines ${PIPELINE_VERSION}"
 kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/${PIPELINE_VERSION}/release.yaml"
 echo "--- Waiting for Tekton Pipelines to be ready"
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-controller -n tekton-pipelines
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-webhook -n tekton-pipelines
+# Wait for every control-plane deployment to be Available (cold kind nodes may
+# still be pulling images), then wait for the admission webhook to actually
+# have ready endpoints before applying any Tekton resources.
+kubectl wait --for=condition=available --timeout=300s \
+    deployment --all -n tekton-pipelines
+echo "--- Waiting for the admission webhook to serve"
+for _ in $(seq 1 30); do
+    if [[ -n "$(kubectl get endpoints tekton-pipelines-webhook \
+        -n tekton-pipelines -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null)" ]]; then
+        break
+    fi
+    sleep 5
+done
 
 echo "--- Installing git-clone task"
 kubectl apply -f "https://raw.githubusercontent.com/tektoncd-catalog/git-clone/v1.6.0/task/git-clone/git-clone.yaml"
@@ -59,29 +70,67 @@ FAILED=0
 PASSED=0
 TOTAL=0
 
+# Snapshot each PipelineRun's spec (stripped of status and volatile metadata)
+# so we can recreate it if it hits a transient flake. Dependency-free: kubectl
+# -o yaml orders keys with status last, so cutting from `status:` to EOF is safe.
+SNAP_DIR="$(mktemp -d)"
+snapshot_run() {
+    kubectl get pipelinerun/"$1" -o yaml --show-managed-fields=false 2>/dev/null \
+        | sed -e '/^status:/,$d' \
+              -e '/^  resourceVersion:/d' \
+              -e '/^  uid:/d' \
+              -e '/^  creationTimestamp:/d' \
+              -e '/^  generation:/d' \
+              -e '/^  selfLink:/d' \
+        > "${SNAP_DIR}/$1.yaml"
+}
+for pr in ${PIPELINERUNS}; do
+    snapshot_run "${pr}"
+done
+
+wait_for_run() {
+    kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" pipelinerun/"$1" 2>/dev/null
+}
+
+dump_run() {
+    echo "  --- PipelineRun status ---"
+    kubectl get pipelinerun/"$1" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
+    echo ""
+    echo "  --- TaskRun details ---"
+    kubectl get taskrun -l tekton.dev/pipelineRun="$1" \
+        -o custom-columns='NAME:.metadata.name,STATUS:.status.conditions[0].reason,MESSAGE:.status.conditions[0].message' 2>/dev/null || true
+    echo ""
+    echo "  --- Pod logs ---"
+    for pod in $(kubectl get pods -l tekton.dev/pipelineRun="$1" -o name 2>/dev/null); do
+        echo "  >> ${pod}"
+        kubectl logs "${pod}" --all-containers 2>/dev/null || true
+    done
+    echo "  ---"
+}
+
 echo "--- Waiting for PipelineRuns to complete (timeout: ${TIMEOUT})"
 for pr in ${PIPELINERUNS}; do
     TOTAL=$((TOTAL + 1))
     echo -n "  ${pr} ... "
-    if kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" pipelinerun/"${pr}" 2>/dev/null; then
+    if wait_for_run "${pr}"; then
+        echo "PASSED"
+        PASSED=$((PASSED + 1))
+        continue
+    fi
+
+    # Retry once: transient pod sandbox / network / image-pull blips on a
+    # single-node kind cluster (many pods starting at once) can stall a pod
+    # before its container ever runs. Recreate the PipelineRun from its
+    # snapshot and wait again before declaring a real failure.
+    echo -n "FLAKY, retrying ... "
+    kubectl delete pipelinerun/"${pr}" --wait=true 2>/dev/null || true
+    kubectl apply -f "${SNAP_DIR}/${pr}.yaml" >/dev/null 2>&1 || true
+    if wait_for_run "${pr}"; then
         echo "PASSED"
         PASSED=$((PASSED + 1))
     else
         echo "FAILED"
-        echo "  --- PipelineRun status ---"
-        kubectl get pipelinerun/"${pr}" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
-        echo ""
-        echo "  --- TaskRun details ---"
-        # Show status of child TaskRuns
-        kubectl get taskrun -l tekton.dev/pipelineRun="${pr}" \
-            -o custom-columns='NAME:.metadata.name,STATUS:.status.conditions[0].reason,MESSAGE:.status.conditions[0].message' 2>/dev/null || true
-        echo ""
-        echo "  --- Pod logs ---"
-        for pod in $(kubectl get pods -l tekton.dev/pipelineRun="${pr}" -o name 2>/dev/null); do
-            echo "  >> ${pod}"
-            kubectl logs "${pod}" --all-containers 2>/dev/null || true
-        done
-        echo "  ---"
+        dump_run "${pr}"
         FAILED=$((FAILED + 1))
     fi
 done

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -31,8 +31,19 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 echo "--- Installing Tekton Pipelines ${PIPELINE_VERSION}"
 kubectl apply --filename "https://github.com/tektoncd/pipeline/releases/download/${PIPELINE_VERSION}/release.yaml"
 echo "--- Waiting for Tekton Pipelines to be ready"
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-controller -n tekton-pipelines
-kubectl wait --for=condition=available --timeout=120s deployment/tekton-pipelines-webhook -n tekton-pipelines
+# Wait for every control-plane deployment to be Available (cold kind nodes may
+# still be pulling images), then wait for the admission webhook to actually
+# have ready endpoints before applying any Tekton resources.
+kubectl wait --for=condition=available --timeout=300s \
+    deployment --all -n tekton-pipelines
+echo "--- Waiting for the admission webhook to serve"
+for _ in $(seq 1 30); do
+    if [[ -n "$(kubectl get endpoints tekton-pipelines-webhook \
+        -n tekton-pipelines -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null)" ]]; then
+        break
+    fi
+    sleep 5
+done
 
 echo "--- Installing git-clone task"
 kubectl apply -f "https://raw.githubusercontent.com/tektoncd-catalog/git-clone/v1.6.0/task/git-clone/git-clone.yaml"
@@ -61,29 +72,67 @@ FAILED=0
 PASSED=0
 TOTAL=0
 
+# Snapshot each PipelineRun's spec (stripped of status and volatile metadata)
+# so we can recreate it if it hits a transient flake. Dependency-free: kubectl
+# -o yaml orders keys with status last, so cutting from `status:` to EOF is safe.
+SNAP_DIR="$(mktemp -d)"
+snapshot_run() {
+    kubectl get pipelinerun/"$1" -o yaml --show-managed-fields=false 2>/dev/null \
+        | sed -e '/^status:/,$d' \
+              -e '/^  resourceVersion:/d' \
+              -e '/^  uid:/d' \
+              -e '/^  creationTimestamp:/d' \
+              -e '/^  generation:/d' \
+              -e '/^  selfLink:/d' \
+        > "${SNAP_DIR}/$1.yaml"
+}
+for pr in ${PIPELINERUNS}; do
+    snapshot_run "${pr}"
+done
+
+wait_for_run() {
+    kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" pipelinerun/"$1" 2>/dev/null
+}
+
+dump_run() {
+    echo "  --- PipelineRun status ---"
+    kubectl get pipelinerun/"$1" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
+    echo ""
+    echo "  --- TaskRun details ---"
+    kubectl get taskrun -l tekton.dev/pipelineRun="$1" \
+        -o custom-columns='NAME:.metadata.name,STATUS:.status.conditions[0].reason,MESSAGE:.status.conditions[0].message' 2>/dev/null || true
+    echo ""
+    echo "  --- Pod logs ---"
+    for pod in $(kubectl get pods -l tekton.dev/pipelineRun="$1" -o name 2>/dev/null); do
+        echo "  >> ${pod}"
+        kubectl logs "${pod}" --all-containers 2>/dev/null || true
+    done
+    echo "  ---"
+}
+
 echo "--- Waiting for PipelineRuns to complete (timeout: ${TIMEOUT})"
 for pr in ${PIPELINERUNS}; do
     TOTAL=$((TOTAL + 1))
     echo -n "  ${pr} ... "
-    if kubectl wait --for=condition=Succeeded --timeout="${TIMEOUT}" pipelinerun/"${pr}" 2>/dev/null; then
+    if wait_for_run "${pr}"; then
+        echo "PASSED"
+        PASSED=$((PASSED + 1))
+        continue
+    fi
+
+    # Retry once: transient pod sandbox / network / image-pull blips on a
+    # single-node kind cluster (many pods starting at once) can stall a pod
+    # before its container ever runs. Recreate the PipelineRun from its
+    # snapshot and wait again before declaring a real failure.
+    echo -n "FLAKY, retrying ... "
+    kubectl delete pipelinerun/"${pr}" --wait=true 2>/dev/null || true
+    kubectl apply -f "${SNAP_DIR}/${pr}.yaml" >/dev/null 2>&1 || true
+    if wait_for_run "${pr}"; then
         echo "PASSED"
         PASSED=$((PASSED + 1))
     else
         echo "FAILED"
-        echo "  --- PipelineRun status ---"
-        kubectl get pipelinerun/"${pr}" -o jsonpath='{.status.conditions[*].message}' 2>/dev/null || true
-        echo ""
-        echo "  --- TaskRun details ---"
-        # Show status of child TaskRuns
-        kubectl get taskrun -l tekton.dev/pipelineRun="${pr}" \
-            -o custom-columns='NAME:.metadata.name,STATUS:.status.conditions[0].reason,MESSAGE:.status.conditions[0].message' 2>/dev/null || true
-        echo ""
-        echo "  --- Pod logs ---"
-        for pod in $(kubectl get pods -l tekton.dev/pipelineRun="${pr}" -o name 2>/dev/null); do
-            echo "  >> ${pod}"
-            kubectl logs "${pod}" --all-containers 2>/dev/null || true
-        done
-        echo "  ---"
+        dump_run "${pr}"
         FAILED=$((FAILED + 1))
     fi
 done


### PR DESCRIPTION
Ports the e2e robustness fixes from tektoncd-catalog/git-clone#127 to all four e2e runners here, which shared the same fragile patterns.

## Flake modes addressed

**1. Control-plane readiness race** — `deployment available` with a 120s timeout was too tight on a cold kind node, and does not guarantee the admission webhook has ready endpoints, so subsequent applies could race an unserved webhook. Now wait for all `tekton-pipelines` deployments (300s) and poll the webhook endpoints until populated before applying any Tekton resources.

**2. Pod sandbox contention** — with many PipelineRuns created at once on a single-node kind cluster, a pod could stall at `PodReadyToStartContainers=False` and never start its container. Each PipelineRun spec is now snapshotted (dependency-free, via `kubectl -o yaml` with status/volatile-metadata stripped) and retried once (delete + recreate) before being declared a failure. The snapshot is taken from the cluster, so it works uniformly for apply-, create/generateName-, and heredoc-created runs.

## Scope

Touches only `e2e-tests.sh`, `e2e-tests-alpine.sh`, `e2e-stepactions.sh`, `e2e-bundle-test.sh`. No change to Tasks, StepActions, base templates, or fixtures. `bash -n` and `shellcheck` clean.